### PR TITLE
Add ability to create and save profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This repository currently provides a minimal prototype with the following featur
 - Data model for profiles and tunnels.
 - Loading and saving profiles from `~/.config/lighthouse/profiles.json`.
 - Basic graphical interface using [Fyne](https://fyne.io/) that lists configured profiles.
+- Ability to create and save new profiles through the interface.
 
 The project is under active development and does not yet implement the full specification.

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -29,9 +30,31 @@ func main() {
 				o.(*widget.Label).SetText(names[i])
 			},
 		)
+
+		addButton := widget.NewButton("Add Profile", func() {
+			nameEntry := widget.NewEntry()
+			ipEntry := widget.NewEntry()
+			dialog.ShowForm("New Profile", "Save", "Cancel", []*widget.FormItem{
+				{Text: "Name", Widget: nameEntry},
+				{Text: "IP Address", Widget: ipEntry},
+			}, func(b bool) {
+				if !b {
+					return
+				}
+				p := Profile{Name: nameEntry.Text, IPAddress: ipEntry.Text}
+				profiles = append(profiles, p)
+				names = append(names, p.Name)
+				list.Refresh()
+				if err := SaveProfiles(profiles); err != nil {
+					log.Println("failed to save profiles:", err)
+				}
+			}, w)
+		})
+
 		w.SetContent(container.NewVBox(
 			widget.NewLabel("Profiles"),
 			list,
+			addButton,
 		))
 	}
 	w.ShowAndRun()


### PR DESCRIPTION
## Summary
- allow users to create profiles from the UI
- persist new profiles to config storage
- document profile creation capability

## Testing
- `go build ./...` *(fails: Package 'gl' not found; X11/Xcursor/Xcursor.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b187c28c6883248cb6d768e92b85fd