### PR TITLE
Add cross-platform build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,28 @@ This repository currently provides a minimal prototype with the following featur
 - Basic graphical interface using [Fyne](https://fyne.io/) that lists configured profiles.
 
 The project is under active development and does not yet implement the full specification.
+
+## Cross-compilation
+
+This project uses [fyne-cross](https://github.com/fyne-io/fyne-cross) to create binaries for multiple platforms.
+
+### Install fyne-cross
+
+```bash
+go install github.com/fyne-io/fyne-cross@latest
+```
+
+Docker must be installed and running.
+
+### Build
+
+```bash
+./build.sh
+```
+
+The build outputs will appear under the `fyne-cross` directory:
+
+- `fyne-cross/linux-amd64`
+- `fyne-cross/windows-amd64`
+- `fyne-cross/darwin-amd64`
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+fyne-cross linux -arch=amd64
+fyne-cross windows -arch=amd64
+fyne-cross darwin -arch=amd64


### PR DESCRIPTION
## Summary
- add build script using fyne-cross for Linux, Windows, and macOS
- document fyne-cross installation and build instructions
- remove GitHub Actions workflow that built cross-platform binaries

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Package gl not found; Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19374b3d88324beb0911fd4371423