### PR TITLE
Add profile persistence and validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,6 +37,11 @@ func LoadProfiles() ([]Profile, error) {
 	if err := json.Unmarshal(data, &profiles); err != nil {
 		return nil, err
 	}
+	for _, p := range profiles {
+		if err := p.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid profile %s: %w", p.Name, err)
+		}
+	}
 	return profiles, nil
 }
 
@@ -47,6 +53,11 @@ func SaveProfiles(profiles []Profile) error {
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
+	}
+	for _, p := range profiles {
+		if err := p.Validate(); err != nil {
+			return fmt.Errorf("invalid profile %s: %w", p.Name, err)
+		}
 	}
 	data, err := json.MarshalIndent(profiles, "", "  ")
 	if err != nil {

--- a/profile.go
+++ b/profile.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
 // Tunnel represents a single SSH tunnel configuration within a profile.
 type Tunnel struct {
 	Name        string `json:"name" yaml:"name"`
@@ -13,9 +19,59 @@ type Tunnel struct {
 	LocalPort   int    `json:"local_port" yaml:"local_port"`
 }
 
+// Validate checks that all required tunnel fields are present.
+func (t Tunnel) Validate() error {
+	if t.Name == "" {
+		return errors.New("tunnel name is required")
+	}
+	if t.SSHServer == "" {
+		return errors.New("ssh_server is required")
+	}
+	if t.SSHPort <= 0 {
+		return errors.New("ssh_port must be > 0")
+	}
+	if t.SSHUser == "" {
+		return errors.New("ssh_user is required")
+	}
+	if t.SSHKeyPath == "" {
+		return errors.New("ssh_key_path is required")
+	}
+	if t.RemoteHost == "" {
+		return errors.New("remote_host is required")
+	}
+	if t.RemotePort <= 0 {
+		return errors.New("remote_port must be > 0")
+	}
+	if t.LocalDomain == "" {
+		return errors.New("local_domain is required")
+	}
+	if t.LocalPort <= 0 {
+		return errors.New("local_port must be > 0")
+	}
+	return nil
+}
+
 // Profile groups multiple tunnels under a single IP address.
 type Profile struct {
 	Name      string   `json:"name" yaml:"name"`
 	IPAddress string   `json:"ip_address" yaml:"ip_address"`
 	Tunnels   []Tunnel `json:"tunnels" yaml:"tunnels"`
+}
+
+// Validate ensures the profile has a loopback IP and valid tunnels.
+func (p Profile) Validate() error {
+	ip := net.ParseIP(p.IPAddress)
+	if ip == nil {
+		return fmt.Errorf("invalid ip address: %s", p.IPAddress)
+	}
+	ip4 := ip.To4()
+	if ip4 == nil || ip4[0] != 127 {
+		return fmt.Errorf("ip address must be in 127.0.0.0/8: %s", p.IPAddress)
+	}
+	for _, t := range p.Tunnels {
+		if err := t.Validate(); err != nil {
+			return fmt.Errorf("tunnel %s: %w", t.Name, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- define Tunnel and Profile structs with validation methods
- support loading/saving profiles with validation from `~/.config/lighthouse/profiles.json`
- enforce loopback IP and required tunnel fields

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1a5ae9fb88324af44dfd215a5aee1