### PR TITLE
Implement profile activation control

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+)
+
+var (
+	activeProfile *Profile
+	activeCmds    []*exec.Cmd
+	mu            sync.Mutex
+)
+
+// ActivateProfile starts all tunnels defined in the given profile. Any previously
+// active profile is deactivated to ensure that only a single profile is running
+// at a time.
+func ActivateProfile(p Profile) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	// If another profile is active, deactivate it first.
+	if activeProfile != nil && activeProfile.Name != p.Name {
+		if err := deactivateLocked(); err != nil {
+			return err
+		}
+	} else if activeProfile != nil && activeProfile.Name == p.Name {
+		// Already active; nothing to do.
+		return nil
+	}
+
+	var cmds []*exec.Cmd
+	for _, t := range p.Tunnels {
+		args := []string{"-N", "-L", fmt.Sprintf("%s:%d:%s:%d", t.LocalDomain, t.LocalPort, t.RemoteHost, t.RemotePort)}
+		if t.SSHKeyPath != "" {
+			args = append(args, "-i", t.SSHKeyPath)
+		}
+		args = append(args, "-p", strconv.Itoa(t.SSHPort), fmt.Sprintf("%s@%s", t.SSHUser, t.SSHServer))
+		cmd := exec.Command("ssh", args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			// stop any started tunnels on error
+			for _, c := range cmds {
+				if c.Process != nil {
+					_ = c.Process.Kill()
+				}
+			}
+			return err
+		}
+		cmds = append(cmds, cmd)
+	}
+
+	activeProfile = &p
+	activeCmds = cmds
+	return nil
+}
+
+// DeactivateProfile stops all tunnels of the currently active profile, if any.
+func DeactivateProfile() error {
+	mu.Lock()
+	defer mu.Unlock()
+	return deactivateLocked()
+}
+
+// deactivateLocked assumes the caller holds mu.
+func deactivateLocked() error {
+	if activeProfile == nil {
+		return nil
+	}
+	for _, c := range activeCmds {
+		if c.Process != nil {
+			if err := c.Process.Kill(); err != nil {
+				return err
+			}
+			_, _ = c.Process.Wait()
+		}
+	}
+	activeProfile = nil
+	activeCmds = nil
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,10 @@ func main() {
 				o.(*widget.Label).SetText(names[i])
 			},
 		)
+		selected := -1
+		list.OnSelected = func(id widget.ListItemID) {
+			selected = int(id)
+		}
 
 		addButton := widget.NewButton("Add Profile", func() {
 			nameEntry := widget.NewEntry()
@@ -51,10 +55,23 @@ func main() {
 			}, w)
 		})
 
+		activateButton := widget.NewButton("Activate", func() {
+			if selected >= 0 && selected < len(profiles) {
+				if err := ActivateProfile(profiles[selected]); err != nil {
+					log.Println("activate profile:", err)
+				}
+			}
+		})
+		deactivateButton := widget.NewButton("Deactivate", func() {
+			if err := DeactivateProfile(); err != nil {
+				log.Println("deactivate profile:", err)
+			}
+		})
+
 		w.SetContent(container.NewVBox(
 			widget.NewLabel("Profiles"),
 			list,
-			addButton,
+			container.NewHBox(activateButton, deactivateButton, addButton),
 		))
 	}
 	w.ShowAndRun()


### PR DESCRIPTION
## Summary
- Add activation manager with ActivateProfile and DeactivateProfile to start and stop SSH tunnels
- Wire UI buttons to activate or deactivate selected profile

## Testing
- `go test ./...` *(fails: Package 'gl' not found; X11/Xcursor/Xcursor.h: No such file or directory)*
- `go build ./...` *(fails: Package 'gl' not found; X11/Xcursor/Xcursor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b04548fc8324a629a44fb3d97d4d