### PR TITLE
Enforce key-only SSH authentication and hosts permission checks

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -33,7 +33,23 @@ func ActivateProfile(p Profile) error {
 
 	var cmds []*exec.Cmd
 	for _, t := range p.Tunnels {
-		args := []string{"-N", "-L", fmt.Sprintf("%s:%d:%s:%d", t.LocalDomain, t.LocalPort, t.RemoteHost, t.RemotePort)}
+		if authProvider != nil {
+			if err := authProvider.Authenticate(t); err != nil {
+				for _, c := range cmds {
+					if c.Process != nil {
+						_ = c.Process.Kill()
+					}
+				}
+				return err
+			}
+		}
+
+		args := []string{
+			"-o", "PreferredAuthentications=publickey",
+			"-o", "PasswordAuthentication=no",
+			"-N",
+			"-L", fmt.Sprintf("%s:%d:%s:%d", t.LocalDomain, t.LocalPort, t.RemoteHost, t.RemotePort),
+		}
 		if t.SSHKeyPath != "" {
 			args = append(args, "-i", t.SSHKeyPath)
 		}

--- a/hosts.go
+++ b/hosts.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -23,12 +22,28 @@ func hostsFile() string {
 	return "/etc/hosts"
 }
 
+// validateHostsPermissions checks if the hosts file is writable.
+func validateHostsPermissions(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("insufficient permissions to modify hosts file: %w", err)
+		}
+		return err
+	}
+	f.Close()
+	return nil
+}
+
 // AddHostEntry appends a mapping of ip to domain in the hosts file.
 // The entry will look like: "<IP> <domain>".
 // If the entry already exists, the function returns without error.
-// If writing requires elevated privileges, sudo will be invoked automatically.
+// Returns an error if the hosts file is not writable.
 func AddHostEntry(ip, domain string) error {
 	path := hostsFile()
+	if err := validateHostsPermissions(path); err != nil {
+		return err
+	}
 	entry := fmt.Sprintf("%s %s", ip, domain)
 
 	data, err := os.ReadFile(path)
@@ -41,11 +56,6 @@ func AddHostEntry(ip, domain string) error {
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		if os.IsPermission(err) {
-			cmd := exec.Command("sudo", "tee", "-a", path)
-			cmd.Stdin = strings.NewReader(entry + "\n")
-			return cmd.Run()
-		}
 		return err
 	}
 	defer f.Close()
@@ -58,9 +68,12 @@ func AddHostEntry(ip, domain string) error {
 
 // RemoveHostEntries removes all host file entries that match the provided ip.
 // If domain is not empty, only entries with both ip and domain will be removed.
-// If writing requires elevated privileges, sudo will be invoked automatically.
+// Returns an error if the hosts file is not writable.
 func RemoveHostEntries(ip, domain string) error {
 	path := hostsFile()
+	if err := validateHostsPermissions(path); err != nil {
+		return err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -89,19 +102,14 @@ func RemoveHostEntries(ip, domain string) error {
 		return nil
 	}
 
-	if err := writeHostsFile(path, buf.Bytes()); err != nil {
-		return err
-	}
-	return nil
+	return writeHostsFile(path, buf.Bytes())
 }
 
-// writeHostsFile writes content to the hosts file handling sudo when needed.
+// writeHostsFile writes content to the hosts file.
 func writeHostsFile(path string, content []byte) error {
 	if err := os.WriteFile(path, content, 0o644); err != nil {
 		if os.IsPermission(err) {
-			cmd := exec.Command("sudo", "tee", path)
-			cmd.Stdin = bytes.NewReader(content)
-			return cmd.Run()
+			return fmt.Errorf("insufficient permissions to modify hosts file: %w", err)
 		}
 		return err
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -18,3 +18,10 @@ type Plugin interface {
 	AuthenticationProvider
 	EventHandler
 }
+
+var authProvider AuthenticationProvider
+
+// RegisterAuthenticationProvider installs the given authentication provider.
+func RegisterAuthenticationProvider(p AuthenticationProvider) {
+	authProvider = p
+}

--- a/ssh_agent_plugin.go
+++ b/ssh_agent_plugin.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// SSHAgentPlugin integrates the system SSH agent for authentication.
+type SSHAgentPlugin struct{}
+
+// Name returns the plugin name.
+func (p *SSHAgentPlugin) Name() string { return "ssh-agent" }
+
+// Authenticate ensures the private key is loaded into the SSH agent.
+func (p *SSHAgentPlugin) Authenticate(t Tunnel) error {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		return errors.New("ssh agent not available")
+	}
+	if t.SSHKeyPath == "" {
+		return errors.New("ssh key path is required")
+	}
+	cmd := exec.Command("ssh-add", t.SSHKeyPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func init() {
+	RegisterAuthenticationProvider(&SSHAgentPlugin{})
+}


### PR DESCRIPTION
## Summary
- ensure SSH only authenticates with private keys
- add plugin system with SSH-agent integration
- validate hosts file write permissions before editing

## Testing
- `gofmt -w plugin.go ssh_agent_plugin.go activation.go hosts.go`
- `go vet ./...` *(fails: process hung, interrupted)*
- `go build ./...` *(fails: missing `gl` pkg-config and X11 headers)*


------
https://chatgpt.com/codex/tasks/task_e_68b1bffba8e4832494e22973a890c772