### PR TITLE
Add reverse proxy tied to profile activation

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -47,6 +47,13 @@ func ActivateProfile(p Profile) error {
 		started = append(started, t)
 	}
 
+	if err := StartProxy(p); err != nil {
+		for _, st := range started {
+			_ = StopTunnel(st)
+		}
+		return err
+	}
+
 	activeProfile = &p
 	activeTunnels = started
 	return nil
@@ -68,6 +75,9 @@ func deactivateLocked() error {
 		if err := StopTunnel(t); err != nil {
 			return err
 		}
+	}
+	if err := StopProxy(); err != nil {
+		return err
 	}
 	activeProfile = nil
 	activeTunnels = nil

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// proxyServer manages an HTTP reverse proxy for active profile tunnels.
+type proxyServer struct {
+	ip     string
+	routes map[string]int // Host -> local port
+	srv    *http.Server
+}
+
+var (
+	proxyMu sync.Mutex
+	proxy   *proxyServer
+)
+
+// StartProxy starts an HTTP reverse proxy for the given profile. The proxy
+// listens on port 80 of the profile IP address and routes requests based on the
+// Host header to the corresponding tunnel's local port.
+func StartProxy(p Profile) error {
+	proxyMu.Lock()
+	defer proxyMu.Unlock()
+	if proxy != nil {
+		return fmt.Errorf("proxy already running")
+	}
+
+	routes := make(map[string]int)
+	for _, t := range p.Tunnels {
+		routes[t.LocalDomain] = t.LocalPort
+	}
+
+	ps := &proxyServer{ip: p.IPAddress, routes: routes}
+	srv := &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", p.IPAddress, 80),
+		Handler: http.HandlerFunc(ps.handle),
+	}
+	ps.srv = srv
+	proxy = ps
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("proxy serve: %v", err)
+		}
+	}()
+	return nil
+}
+
+// StopProxy stops the running reverse proxy, if any.
+func StopProxy() error {
+	proxyMu.Lock()
+	ps := proxy
+	proxy = nil
+	proxyMu.Unlock()
+	if ps == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return ps.srv.Shutdown(ctx)
+}
+
+func (ps *proxyServer) handle(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	if i := strings.Index(host, ":"); i >= 0 {
+		host = host[:i]
+	}
+	port, ok := ps.routes[host]
+	if !ok {
+		http.Error(w, "no route", http.StatusBadGateway)
+		return
+	}
+	targetURL := &url.URL{Scheme: "http", Host: fmt.Sprintf("%s:%d", ps.ip, port)}
+	httputil.NewSingleHostReverseProxy(targetURL).ServeHTTP(w, r)
+}


### PR DESCRIPTION
## Summary
- start a httputil.ReverseProxy for active profile host mappings
- map Host headers to corresponding tunnel ports
- ensure proxy lifecycle matches profile activation

## Testing
- `go test ./...` *(fails: Package 'gl' not found; X11/Xcursor/Xcursor.h: No such file or directory)*
- `go build ./...` *(fails: Package 'gl' not found; X11/Xcursor/Xcursor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c46c36e4832490535192c220c80c