### PR TITLE
Refactor proxy to TCP listeners per tunnel

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -3,20 +3,22 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"strings"
+	"net"
 	"sync"
-	"time"
 )
 
-// proxyServer manages an HTTP reverse proxy for active profile tunnels.
+type proxyListener struct {
+	net.Listener
+	localPort int
+}
+
 type proxyServer struct {
-	ip     string
-	routes map[string]int // Host -> local port
-	srv    *http.Server
+	ip        string
+	listeners []proxyListener
+	ctx       context.Context
+	cancel    context.CancelFunc
 }
 
 var (
@@ -24,9 +26,8 @@ var (
 	proxy   *proxyServer
 )
 
-// StartProxy starts an HTTP reverse proxy for the given profile. The proxy
-// listens on port 80 of the profile IP address and routes requests based on the
-// Host header to the corresponding tunnel's local port.
+// StartProxy starts TCP listeners for each tunnel, forwarding connections to
+// the corresponding local ports.
 func StartProxy(p Profile) error {
 	proxyMu.Lock()
 	defer proxyMu.Unlock()
@@ -34,28 +35,29 @@ func StartProxy(p Profile) error {
 		return fmt.Errorf("proxy already running")
 	}
 
-	routes := make(map[string]int)
+	ctx, cancel := context.WithCancel(context.Background())
+	ps := &proxyServer{ip: p.IPAddress, ctx: ctx, cancel: cancel}
+
 	for _, t := range p.Tunnels {
-		routes[t.LocalDomain] = t.LocalPort
-	}
-
-	ps := &proxyServer{ip: p.IPAddress, routes: routes}
-	srv := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", p.IPAddress, 80),
-		Handler: http.HandlerFunc(ps.handle),
-	}
-	ps.srv = srv
-	proxy = ps
-
-	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("proxy serve: %v", err)
+		addr := fmt.Sprintf("%s:%d", p.IPAddress, t.RemotePort)
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			cancel()
+			for _, pl := range ps.listeners {
+				pl.Close()
+			}
+			return err
 		}
-	}()
+		pl := proxyListener{Listener: l, localPort: t.LocalPort}
+		ps.listeners = append(ps.listeners, pl)
+		go ps.acceptLoop(ctx, pl)
+	}
+
+	proxy = ps
 	return nil
 }
 
-// StopProxy stops the running reverse proxy, if any.
+// StopProxy stops all running TCP listeners.
 func StopProxy() error {
 	proxyMu.Lock()
 	ps := proxy
@@ -64,21 +66,55 @@ func StopProxy() error {
 	if ps == nil {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	return ps.srv.Shutdown(ctx)
+
+	ps.cancel()
+	var firstErr error
+	for _, pl := range ps.listeners {
+		if err := pl.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
-func (ps *proxyServer) handle(w http.ResponseWriter, r *http.Request) {
-	host := r.Host
-	if i := strings.Index(host, ":"); i >= 0 {
-		host = host[:i]
+func (ps *proxyServer) acceptLoop(ctx context.Context, pl proxyListener) {
+	for {
+		c, err := pl.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				log.Printf("proxy accept: %v", err)
+				continue
+			}
+		}
+		go ps.handleConn(ctx, c, pl.localPort)
 	}
-	port, ok := ps.routes[host]
-	if !ok {
-		http.Error(w, "no route", http.StatusBadGateway)
+}
+
+func (ps *proxyServer) handleConn(ctx context.Context, conn net.Conn, port int) {
+	dstAddr := fmt.Sprintf("%s:%d", ps.ip, port)
+	dst, err := net.Dial("tcp", dstAddr)
+	if err != nil {
+		log.Printf("proxy dial: %v", err)
+		conn.Close()
 		return
 	}
-	targetURL := &url.URL{Scheme: "http", Host: fmt.Sprintf("%s:%d", ps.ip, port)}
-	httputil.NewSingleHostReverseProxy(targetURL).ServeHTTP(w, r)
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-ctx.Done()
+		conn.Close()
+		dst.Close()
+	}()
+	go func() {
+		io.Copy(dst, conn)
+		cancel()
+	}()
+	go func() {
+		io.Copy(conn, dst)
+		cancel()
+	}()
+	<-ctx.Done()
 }


### PR DESCRIPTION
## Summary
- replace HTTP reverse proxy with TCP proxy using net.Listen and net.Dial
- manage separate listeners per tunnel and forward data with io.Copy and context cancelation

## Testing
- ⚠️ `go test ./...` *(terminated after hanging)*
- ⚠️ `go build ./...` *(terminated after hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ccf02b308324b51b09aebb94b0d6