### PR TITLE
feat: fallback config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Lighthouse is a cross-platform utility for managing SSH tunnels and local domain
 This repository currently provides a minimal prototype with the following features:
 
 - Data model for profiles and tunnels.
-- Loading and saving profiles from `~/.config/lighthouse/profiles.json`.
+- Loading and saving profiles from the user's configuration directory (e.g.
+  `~/.config/lighthouse/profiles.json`) or the current working directory if no
+  user configuration directory can be determined.
 - Basic graphical interface using [Fyne](https://fyne.io/) that lists configured profiles.
 - Ability to create and save new profiles through the interface.
 

--- a/config.go
+++ b/config.go
@@ -13,10 +13,14 @@ import (
 const defaultConfigFile = "profiles.json"
 
 // configDir returns the directory where user specific configuration is stored.
+// It first attempts to locate the user's configuration directory via
+// os.UserConfigDir(). If that fails, it falls back to the current working
+// directory so that profiles can still be read and written.
 func configDir() (string, error) {
 	dir, err := os.UserConfigDir()
 	if err != nil {
-		return "", err
+		wd, _ := os.Getwd()
+		return wd, nil
 	}
 	return filepath.Join(dir, "lighthouse"), nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConfigDirFallback verifies that profiles can be saved and loaded when
+// the user configuration directory cannot be determined.
+func TestConfigDirFallback(t *testing.T) {
+	// Unset environment variables so os.UserConfigDir fails.
+	origHome := os.Getenv("HOME")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("HOME", origHome)
+	if origXDG != "" {
+		defer os.Setenv("XDG_CONFIG_HOME", origXDG)
+	}
+
+	// Use a temporary working directory.
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Saving and loading an empty profile list should succeed and use the
+	// working directory for storage.
+	if err := SaveProfiles([]Profile{}); err != nil {
+		t.Fatalf("SaveProfiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, defaultConfigFile)); err != nil {
+		t.Fatalf("expected config file in working directory: %v", err)
+	}
+	profiles, err := LoadProfiles()
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Fatalf("expected zero profiles, got %d", len(profiles))
+	}
+}


### PR DESCRIPTION
## Summary
- fall back to the working directory when os.UserConfigDir fails
- document configuration search logic
- test profile loading/saving when no user config directory is available

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6351fd08324973031c8fbdc5fa5