### PR TITLE
Detect OS-specific config paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,25 +4,37 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 const defaultConfigFile = "profiles.json"
 
 // configDir returns the directory where user specific configuration is stored.
-// It first attempts to locate the user's configuration directory via
-// os.UserConfigDir(). If that fails, it falls back to the current working
-// directory so that profiles can still be read and written.
+// The location varies depending on the operating system:
+//
+//	Windows:   directory where the program is executed
+//	Linux/macOS/Android: ~/.config/lighthouse
+//	others:    current working directory
+//
+// If the home directory cannot be determined, the current working directory is
+// used as a fallback so that profiles can still be read and written.
 func configDir() (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		wd, _ := os.Getwd()
-		return wd, nil
+	switch runtime.GOOS {
+	case "windows":
+		return os.Getwd()
+	case "linux", "darwin", "android":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			wd, _ := os.Getwd()
+			return wd, nil
+		}
+		return filepath.Join(home, ".config", "lighthouse"), nil
+	default:
+		return os.Getwd()
 	}
-	return filepath.Join(dir, "lighthouse"), nil
 }
 
 // LoadProfiles reads profiles from the configuration file.
@@ -34,7 +46,7 @@ func LoadProfiles() ([]Profile, error) {
 	}
 	path := filepath.Join(dir, defaultConfigFile)
 	log.Printf("loading profiles from %s", path)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		log.Printf("config file %s not found", path)
 		return []Profile{}, nil
@@ -53,6 +65,7 @@ func LoadProfiles() ([]Profile, error) {
 			log.Printf("invalid profile %s: %v", p.Name, err)
 			return nil, fmt.Errorf("invalid profile %s: %w", p.Name, err)
 		}
+		log.Printf("loaded profile %s", p.Name)
 	}
 	return profiles, nil
 }
@@ -63,17 +76,36 @@ func SaveProfiles(profiles []Profile) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
+	path := filepath.Join(dir, defaultConfigFile)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Printf("create config directory %s: %v", dir, err)
+			return err
+		}
+		log.Printf("created config directory %s", dir)
 	}
+
 	for _, p := range profiles {
 		if err := p.Validate(); err != nil {
 			return fmt.Errorf("invalid profile %s: %w", p.Name, err)
 		}
+		log.Printf("saving profile %s", p.Name)
 	}
+
 	data, err := json.MarshalIndent(profiles, "", "  ")
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(dir, defaultConfigFile), data, 0o600)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Printf("creating config file %s", path)
+	} else if err == nil {
+		log.Printf("updating config file %s", path)
+	} else {
+		log.Printf("stat config file %s: %v", path, err)
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o600)
 }


### PR DESCRIPTION
## Summary
- Choose profile storage directory explicitly based on runtime OS
- Log profile loading, saving, and creation of config directories/files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b26586b26c832480bf8233fbe0477a