### PR TITLE
Add SaveProfile helper to update single profile

### DIFF
--- a/config.go
+++ b/config.go
@@ -109,3 +109,31 @@ func SaveProfiles(profiles []Profile) error {
 
 	return os.WriteFile(path, data, 0o600)
 }
+
+// SaveProfile updates or adds a single profile and writes the full profile list
+// to the configuration file.
+func SaveProfile(p Profile) error {
+	profiles, err := LoadProfiles()
+	if err != nil {
+		return err
+	}
+
+	if err := p.Validate(); err != nil {
+		return fmt.Errorf("invalid profile %s: %w", p.Name, err)
+	}
+	log.Printf("saving profile %s", p.Name)
+
+	updated := false
+	for i, existing := range profiles {
+		if existing.Name == p.Name {
+			profiles[i] = p
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		profiles = append(profiles, p)
+	}
+
+	return SaveProfiles(profiles)
+}


### PR DESCRIPTION
## Summary
- implement SaveProfile to load existing profiles, update or add one, and save list
- include validation and logging similar to SaveProfiles

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b27cd102a483248661501c468a9ee8