### PR TITLE
Add persistence test for profile tunnels

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -44,5 +45,74 @@ func TestConfigDirFallback(t *testing.T) {
 	}
 	if len(profiles) != 0 {
 		t.Fatalf("expected zero profiles, got %d", len(profiles))
+	}
+}
+
+// TestProfileTunnelPersistence ensures that tunnels are preserved across save and load operations.
+func TestProfileTunnelPersistence(t *testing.T) {
+	// Unset environment variables so os.UserConfigDir fails and configDir uses the working directory.
+	origHome := os.Getenv("HOME")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("HOME", origHome)
+	if origXDG != "" {
+		defer os.Setenv("XDG_CONFIG_HOME", origXDG)
+	}
+
+	// Use a temporary working directory.
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	original := Profile{
+		Name:      "p1",
+		IPAddress: "127.0.0.1",
+		Tunnels: []Tunnel{
+			{
+				Name:        "t1",
+				SSHServer:   "ssh.example.com",
+				SSHPort:     22,
+				SSHUser:     "user1",
+				SSHKeyPath:  "/path/to/key1",
+				RemoteHost:  "remote1",
+				RemotePort:  80,
+				LocalDomain: "local1",
+				LocalPort:   8080,
+			},
+			{
+				Name:        "t2",
+				SSHServer:   "ssh.example.org",
+				SSHPort:     2222,
+				SSHUser:     "user2",
+				SSHKeyPath:  "/path/to/key2",
+				RemoteHost:  "remote2",
+				RemotePort:  443,
+				LocalDomain: "local2",
+				LocalPort:   8443,
+			},
+		},
+	}
+
+	if err := SaveProfiles([]Profile{original}); err != nil {
+		t.Fatalf("SaveProfiles: %v", err)
+	}
+
+	loaded, err := LoadProfiles()
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(loaded))
+	}
+	if !reflect.DeepEqual(original, loaded[0]) {
+		t.Fatalf("loaded profile does not match original\noriginal: %#v\nloaded: %#v", original, loaded[0])
 	}
 }


### PR DESCRIPTION
## Summary
- add TestProfileTunnelPersistence to ensure tunnels survive save/load round trip

## Testing
- `CGO_ENABLED=0 go test -run TestProfileTunnelPersistence -v` *(fails: package requires cgo)*

------
https://chatgpt.com/codex/tasks/task_e_68b287efed6c8324a5ef3c08557e97b6