### PR TITLE
Persist profile when adding tunnel

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -116,3 +116,63 @@ func TestProfileTunnelPersistence(t *testing.T) {
 		t.Fatalf("loaded profile does not match original\noriginal: %#v\nloaded: %#v", original, loaded[0])
 	}
 }
+
+// TestAddTunnelSavesProfile verifies that adding a tunnel to a profile also
+// persists the updated profile to disk.
+func TestAddTunnelSavesProfile(t *testing.T) {
+	// Unset environment variables so os.UserConfigDir fails and configDir uses the working directory.
+	origHome := os.Getenv("HOME")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("HOME", origHome)
+	if origXDG != "" {
+		defer os.Setenv("XDG_CONFIG_HOME", origXDG)
+	}
+
+	// Use a temporary working directory.
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	p := Profile{Name: "p1", IPAddress: "127.0.0.1"}
+	if err := SaveProfiles([]Profile{p}); err != nil {
+		t.Fatalf("SaveProfiles: %v", err)
+	}
+
+	tnl := Tunnel{
+		Name:        "t1",
+		SSHServer:   "ssh.example.com",
+		SSHPort:     22,
+		SSHUser:     "user",
+		SSHKeyPath:  "/path/to/key",
+		RemoteHost:  "remote",
+		RemotePort:  80,
+		LocalDomain: "local",
+		LocalPort:   8080,
+	}
+
+	if err := p.AddTunnel(tnl); err != nil {
+		t.Fatalf("AddTunnel: %v", err)
+	}
+
+	loaded, err := LoadProfiles()
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(loaded))
+	}
+	if len(loaded[0].Tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(loaded[0].Tunnels))
+	}
+	if !reflect.DeepEqual(tnl, loaded[0].Tunnels[0]) {
+		t.Fatalf("loaded tunnel does not match added tunnel\nexpected: %#v\nloaded: %#v", tnl, loaded[0].Tunnels[0])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -208,9 +208,8 @@ func main() {
 				return
 			}
 			showTunnelDialog(w, "New Tunnel", nil, func(t Tunnel) {
-				profiles[selected].Tunnels = append(profiles[selected].Tunnels, t)
-				if err := SaveProfile(profiles[selected]); err != nil {
-					log.Println("failed to save profile:", err)
+				if err := profiles[selected].AddTunnel(t); err != nil {
+					log.Println("failed to add tunnel:", err)
 				}
 				tunnelList.Refresh()
 			})

--- a/profile.go
+++ b/profile.go
@@ -75,3 +75,13 @@ func (p Profile) Validate() error {
 	}
 	return nil
 }
+
+// AddTunnel appends a new tunnel to the profile and persists the updated
+// profile to disk. The tunnel configuration is validated before saving.
+func (p *Profile) AddTunnel(t Tunnel) error {
+	if err := t.Validate(); err != nil {
+		return fmt.Errorf("invalid tunnel %s: %w", t.Name, err)
+	}
+	p.Tunnels = append(p.Tunnels, t)
+	return SaveProfile(*p)
+}


### PR DESCRIPTION
## Summary
- add `Profile.AddTunnel` to validate tunnels and save profile to disk
- update GUI to use new `AddTunnel` method
- test that adding a tunnel persists the profile file

## Testing
- `go test ./...` *(fails: Package gl was not found in the pkg-config search path; Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b28de615fc83249e91c34e574ad85c