### PR TITLE
Add detailed logging for host and tunnel operations

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -51,6 +52,7 @@ func AddHostEntry(ip, domain string) error {
 		return err
 	}
 	if strings.Contains(string(data), entry) {
+		log.Printf("hosts entry already exists: %s", entry)
 		return nil
 	}
 
@@ -63,6 +65,7 @@ func AddHostEntry(ip, domain string) error {
 	if _, err := fmt.Fprintln(f, entry); err != nil {
 		return err
 	}
+	log.Printf("added hosts entry: %s", entry)
 	return nil
 }
 
@@ -99,10 +102,19 @@ func RemoveHostEntries(ip, domain string) error {
 	}
 
 	if !removed {
+		log.Printf("no hosts entry found for %s %s", ip, domain)
 		return nil
 	}
 
-	return writeHostsFile(path, buf.Bytes())
+	if err := writeHostsFile(path, buf.Bytes()); err != nil {
+		return err
+	}
+	if domain == "" {
+		log.Printf("removed hosts entries for %s", ip)
+	} else {
+		log.Printf("removed hosts entry: %s %s", ip, domain)
+	}
+	return nil
 }
 
 // writeHostsFile writes content to the hosts file.

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 	logFile, err := os.OpenFile("lighthouse.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err == nil {
 		log.SetOutput(io.MultiWriter(os.Stderr, logFile))
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
 		defer logFile.Close()
 	} else {
 		log.Printf("open log file: %v", err)

--- a/tunnel.go
+++ b/tunnel.go
@@ -76,6 +76,7 @@ func StopTunnel(p Profile, t Tunnel) error {
 		log.Printf("stopped tunnel %s", t.Name)
 	}
 	if err := RemoveHostEntries(p.IPAddress, t.Domain); err != nil {
+		log.Printf("failed to remove hosts entry for %s %s: %v", p.IPAddress, t.Domain, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary
- add file logging setup with timestamps and source locations
- log host file entry additions/removals
- record errors removing hosts when stopping tunnels

## Testing
- `go test ./...` *(fails: Package gl was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68b29c90863083248237439631687d4c