### PR TITLE
Add profile activation/deactivation logs

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"sync"
 )
 
@@ -56,6 +57,7 @@ func ActivateProfile(p Profile) error {
 
 	activeProfile = &p
 	activeTunnels = started
+	log.Printf("activated profile %s", p.Name)
 	return nil
 }
 
@@ -79,6 +81,7 @@ func deactivateLocked() error {
 	if err := StopProxy(); err != nil {
 		return err
 	}
+	log.Printf("deactivated profile %s", activeProfile.Name)
 	activeProfile = nil
 	activeTunnels = nil
 	return nil


### PR DESCRIPTION
## Summary
- log when profiles are activated and deactivated

## Testing
- `go test ./...` *(fails: Package gl was not found; Xrandr header missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cbd23fa883249a75ee822f71b22e