### PR TITLE
Add proxy connection logging

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -91,6 +91,7 @@ func (ps *proxyServer) acceptLoop(ctx context.Context, pl proxyListener) {
 				continue
 			}
 		}
+		log.Printf("proxy accepted %s for port %d", c.RemoteAddr(), pl.localPort)
 		go ps.handleConn(ctx, c, pl.localPort)
 	}
 }
@@ -103,6 +104,7 @@ func (ps *proxyServer) handleConn(ctx context.Context, conn net.Conn, port int) 
 		conn.Close()
 		return
 	}
+	log.Printf("proxy forwarding %s to %s:%d", conn.RemoteAddr(), ps.ip, port)
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
@@ -119,4 +121,5 @@ func (ps *proxyServer) handleConn(ctx context.Context, conn net.Conn, port int) 
 		cancel()
 	}()
 	<-ctx.Done()
+	log.Printf("proxy connection %s closed", conn.RemoteAddr())
 }


### PR DESCRIPTION
## Summary
- add logs for accepted connections, forwarding, and connection closure in proxy server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2cde0fa748324a12270e867e32152