### PR TITLE
Fix pane layout restoration timing

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -121,7 +121,6 @@ class LighthouseApp:
         )
         self.top_pane.grid(row=0, column=0, columnspan=3, sticky="nsew")
         self.top_pane.bind("<ButtonRelease-1>", self._on_pane_resize)
-        self._restore_pane_layout()
 
         # Profiles list
         profile_frame = tk.Frame(self.top_pane, bd=2, relief=tk.GROOVE)
@@ -142,6 +141,10 @@ class LighthouseApp:
         self.top_pane.add(info_frame, minsize=200)
         info_frame.rowconfigure(0, weight=3)
         info_frame.rowconfigure(1, weight=1)
+
+        # Restore pane layout after all panes have been added.
+        # Calling this earlier results in errors because sashes do not yet exist.
+        self._restore_pane_layout()
 
         self.status_text = tk.Text(info_frame, height=10)
         self.status_text.grid(row=0, column=0, sticky="nsew")

--- a/tests/test_restore_pane_layout.py
+++ b/tests/test_restore_pane_layout.py
@@ -1,0 +1,96 @@
+"""Verify that pane layout restoration occurs after panes are created."""
+
+import configparser
+from pathlib import Path
+import types
+
+import pytest
+
+# Ensure module import
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_coords():
+    """Read coordinates from the sample configuration file."""
+    cfg = configparser.ConfigParser()
+    sample = Path(__file__).with_name("pane_layout_sample.ini")
+    cfg.read(sample)
+    return [
+        cfg.getint("panes", key)
+        for key in sorted(cfg["panes"], key=lambda k: int(k.split("_")[-1]))
+    ]
+
+
+def test_restore_pane_layout_after_panes(monkeypatch):
+    coords = _expected_coords()
+
+    # Fake Tkinter module with minimal functionality to avoid GUI dependency
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def bind(self, *args, **kwargs):
+            pass
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def insert(self, *args, **kwargs):
+            pass
+
+    class DummyPanedWindow(DummyWidget):
+        def __init__(self, root, **kwargs):
+            super().__init__(root, **kwargs)
+            self.children = []
+            self.sashes = {}
+
+        def add(self, child, **kwargs):
+            self.children.append(child)
+
+        def panes(self):
+            return self.children
+
+        def sash_place(self, idx, x, y):
+            if idx >= len(self.children) - 1:
+                raise ValueError("sash index out of range")
+            self.sashes[idx] = (x, y)
+
+    fake_tk = types.SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        Listbox=DummyWidget,
+        Text=DummyWidget,
+        Button=DummyWidget,
+        END="end",
+        HORIZONTAL="horizontal",
+        BOTH="both",
+        GROOVE="groove",
+    )
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: coords)
+
+    class DummyRoot(DummyWidget):
+        pass
+
+    cfg = configparser.ConfigParser()
+    cfg["ui"] = {}
+    root = DummyRoot()
+
+    app = ui.LighthouseApp(root, cfg)
+
+    assert app.top_pane.sashes[0][0] == coords[0]
+    assert app.top_pane.sashes[1][0] == coords[1]
+


### PR DESCRIPTION
## Summary
- restore pane layout only after panes are created to avoid missing sash errors
- add regression test using a stub Tkinter environment to ensure coordinates are applied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57390f7b88324b29314273b92e9a9