### PR TITLE
docs: add Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@
    python -m lighthouse_app.ui
    ```
 
+## Сборка в исполняемый файл для Windows
+
+Чтобы получить самостоятельный `.exe` файл, воспользуйтесь стандартным инструментом [PyInstaller](https://pyinstaller.org):
+
+1. Установите PyInstaller:
+   ```bash
+   pip install pyinstaller
+   ```
+2. В каталоге проекта выполните:
+   ```bash
+   pyinstaller --onefile --windowed --name Lighthouse lighthouse_app/ui.py
+   ```
+3. Готовый `Lighthouse.exe` появится в папке `dist`. Скопируйте рядом файл `config.ini` и при необходимости `pane_layout.ini`.
+4. Запустите `Lighthouse.exe` двойным щелчком или через командную строку.
+
 ## Тестирование
 
 Тесты используют значения из файла `config.ini` для проверки корректности конфигурации.


### PR DESCRIPTION
## Summary
- document how to build a standalone Windows executable using PyInstaller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57618a91c83249a464c2fd1828509