### PR TITLE
Delay pane layout restoration until widgets exist

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -144,7 +144,7 @@ class LighthouseApp:
 
         # Restore pane layout after all panes have been added.
         # Calling this earlier results in errors because sashes do not yet exist.
-        self._restore_pane_layout()
+        self.root.after(0, self._restore_pane_layout)
 
         self.status_text = tk.Text(info_frame, height=10)
         self.status_text.grid(row=0, column=0, sticky="nsew")
@@ -173,6 +173,8 @@ class LighthouseApp:
     def _restore_pane_layout(self) -> None:
         """Apply saved pane positions if available."""
         coords = load_pane_layout()
+        # Ensure geometry calculations are current before placing sashes.
+        self.root.update_idletasks()
         for idx, x in enumerate(coords):
             try:
                 self.top_pane.sash_place(idx, x, 0)

--- a/tests/test_restore_pane_layout.py
+++ b/tests/test_restore_pane_layout.py
@@ -50,6 +50,14 @@ def test_restore_pane_layout_after_panes(monkeypatch):
         def insert(self, *args, **kwargs):
             pass
 
+        def after(self, delay, callback, *args):
+            """Immediately invoke callbacks scheduled with 'after'."""
+            callback(*args)
+
+        def update_idletasks(self):
+            """Stub to mirror tk widget method in tests."""
+            pass
+
     class DummyPanedWindow(DummyWidget):
         def __init__(self, root, **kwargs):
             super().__init__(root, **kwargs)


### PR DESCRIPTION
## Summary
- Schedule pane layout restoration to run after the UI is fully initialized
- Refresh geometry with `update_idletasks` before restoring sash positions
- Update tests to mimic Tkinter's timing behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5799f0f2c83249b0b10e1cd444e48