### PR TITLE
Ensure info pane resizes with window

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -155,6 +155,8 @@ class LighthouseApp:
         info_frame.rowconfigure(0, weight=3)
         info_frame.rowconfigure(1, weight=1)
         info_frame.rowconfigure(2, weight=0)
+        # Ensure the info and log section stretches horizontally with window
+        info_frame.columnconfigure(0, weight=1)
 
         # Restore pane layout after all panes have been added.
         # Calling this earlier results in errors because sashes do not yet exist.

--- a/tests/info_pane_layout.ini
+++ b/tests/info_pane_layout.ini
@@ -1,0 +1,2 @@
+[layout]
+info_frame_column_weight = 1

--- a/tests/test_info_pane_layout.py
+++ b/tests/test_info_pane_layout.py
@@ -1,0 +1,87 @@
+"""Ensure the info/log pane stretches with the window width."""
+
+import configparser
+from pathlib import Path
+import types
+import sys
+
+# Make application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_weight() -> int:
+    """Read expected column weight from configuration file."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("info_pane_layout.ini"))
+    return cfg.getint("layout", "info_frame_column_weight")
+
+
+def test_info_frame_expands_with_window(monkeypatch):
+    expected_weight = _expected_weight()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets used in tests."""
+        def __init__(self, *args, **kwargs):
+            self.column_weights = {}
+            self.row_weights = {}
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def bind(self, *args, **kwargs):
+            pass
+
+        def rowconfigure(self, index, weight=0, **kwargs):
+            self.row_weights[index] = weight
+
+        def columnconfigure(self, index, weight=0, **kwargs):
+            self.column_weights[index] = weight
+
+        def insert(self, *args, **kwargs):
+            pass
+
+        def after(self, delay, callback, *args):
+            callback(*args)
+
+        def update_idletasks(self):
+            pass
+
+    class DummyPanedWindow(DummyWidget):
+        def __init__(self, root, **kwargs):
+            super().__init__(root, **kwargs)
+            self.children = []
+
+        def add(self, child, **kwargs):
+            self.children.append(child)
+
+        def panes(self):
+            return self.children
+
+    fake_tk = types.SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        Listbox=DummyWidget,
+        Text=DummyWidget,
+        Button=DummyWidget,
+        END="end",
+        HORIZONTAL="horizontal",
+        BOTH="both",
+        GROOVE="groove",
+    )
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
+
+    cfg = configparser.ConfigParser()
+    cfg["ui"] = {}
+    root = DummyWidget()
+
+    app = ui.LighthouseApp(root, cfg)
+
+    info_frame = app.top_pane.children[2]
+    assert info_frame.column_weights.get(0) == expected_weight


### PR DESCRIPTION
## Summary
- Make the info/log pane expand horizontally with the main window
- Add config-driven test ensuring the pane's column weight is set for resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a729cbfc8324a9d0251bd0f7ca3a