### PR TITLE
Expand SSH key manager window and show descriptions

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -270,6 +270,9 @@ class SSHKeyManager:
         self.logger = logging.getLogger(__name__)
         self.top = tk.Toplevel(parent)
         self.top.title("SSH Keys")
+        # Make the management window wider for better readability of
+        # key names and their descriptions.
+        self.top.geometry("600x400")
 
         self.key_list = tk.Listbox(self.top)
         self.key_list.pack(fill=tk.BOTH, expand=True)
@@ -287,7 +290,8 @@ class SSHKeyManager:
         try:
             keys = load_ssh_keys()
             for key in keys:
-                self.key_list.insert(tk.END, key["name"])
+                display = f"{key['name']} - {key.get('description', '')}"
+                self.key_list.insert(tk.END, display)
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.exception("Failed to load SSH keys: %s", exc)
 
@@ -306,7 +310,8 @@ class SSHKeyManager:
         name, path, desc = dialog.result
         try:
             key = create_ssh_key(name, path, desc)
-            self.key_list.insert(tk.END, key["name"])
+            display = f"{key['name']} - {key.get('description', '')}"
+            self.key_list.insert(tk.END, display)
             messagebox.showinfo("Success", f"SSH key '{key['name']}' added")
         except Exception as exc:
             self.logger.exception("Failed to add SSH key: %s", exc)
@@ -320,7 +325,8 @@ class SSHKeyManager:
             self.logger.info("SSH key edit cancelled: no key selected")
             return
         index = selection[0]
-        name = self.key_list.get(index)
+        selected = self.key_list.get(index)
+        name = selected.split(" - ", 1)[0]
         try:
             keys = load_ssh_keys()
             key = next((k for k in keys if k.get("name") == name), None)
@@ -339,8 +345,9 @@ class SSHKeyManager:
         new_name, path, desc = dialog.result
         try:
             updated = update_ssh_key(name, new_name, path, desc)
+            display = f"{updated['name']} - {updated.get('description', '')}"
             self.key_list.delete(index)
-            self.key_list.insert(index, updated["name"])
+            self.key_list.insert(index, display)
             messagebox.showinfo("Success", f"SSH key '{updated['name']}' updated")
             self.logger.info("SSH key '%s' updated", updated["name"])
         except Exception as exc:
@@ -355,7 +362,8 @@ class SSHKeyManager:
             self.logger.info("SSH key deletion cancelled: no key selected")
             return
         index = selection[0]
-        name = self.key_list.get(index)
+        selected = self.key_list.get(index)
+        name = selected.split(" - ", 1)[0]
         if not messagebox.askyesno("Confirm", f"Delete SSH key '{name}'?"):
             self.logger.info("SSH key deletion cancelled by user")
             return

--- a/tests/ssh_keys_test_config.ini
+++ b/tests/ssh_keys_test_config.ini
@@ -16,3 +16,6 @@ description = Updated main key
 [expected]
 updated_name = MainKeyUpdated
 updated_description = Updated main key
+
+[ui]
+window_width = 600

--- a/tests/test_ssh_key_manager_ui.py
+++ b/tests/test_ssh_key_manager_ui.py
@@ -1,0 +1,80 @@
+"""Tests for SSHKeyManager UI behaviour."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load test configuration for SSH key manager."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("ssh_keys_test_config.ini"))
+    return cfg
+
+
+def test_manager_displays_description_and_sets_width(monkeypatch) -> None:
+    """List should contain name and description and window should be wider."""
+    cfg = _load_cfg()
+    inserted = []
+    geometry_calls = []
+
+    class DummyListbox:
+        def __init__(self, master=None):
+            pass
+        def pack(self, *args, **kwargs):
+            pass
+        def insert(self, index, item):
+            inserted.append(item)
+        def curselection(self):
+            return ()
+        def get(self, index):
+            return inserted[index]
+        def delete(self, index):
+            inserted.pop(index)
+
+    class DummyButton:
+        def __init__(self, master=None, text="", command=None):
+            pass
+        def pack(self, *args, **kwargs):
+            pass
+
+    class DummyToplevel:
+        def __init__(self, master=None):
+            pass
+        def title(self, text):
+            pass
+        def geometry(self, geom):
+            geometry_calls.append(geom)
+
+    fake_tk = SimpleNamespace(
+        Toplevel=DummyToplevel,
+        Listbox=DummyListbox,
+        Button=DummyButton,
+        BOTH="both",
+        END="end",
+    )
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(
+        ui,
+        "load_ssh_keys",
+        lambda: [
+            {
+                "name": cfg["key1"]["name"],
+                "description": cfg["key1"]["description"],
+            }
+        ],
+    )
+
+    ui.SSHKeyManager(None)
+
+    expected_item = f"{cfg['key1']['name']} - {cfg['key1']['description']}"
+    assert inserted == [expected_item]
+    expected_width = cfg["ui"]["window_width"]
+    assert any(g.startswith(expected_width) for g in geometry_calls)


### PR DESCRIPTION
## Summary
- Make SSH key manager dialog wider for improved readability
- Display both name and description for SSH keys in the manager
- Test window width and description display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bacaaa50832482e81767b001a84f