### PR TITLE
Remove popups after SSH key changes

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -325,7 +325,7 @@ class SSHKeyManager:
                 tk.END,
                 values=(key["name"], key.get("description", "")),
             )
-            messagebox.showinfo("Success", f"SSH key '{key['name']}' added")
+            self.logger.info("SSH key '%s' added", key["name"])
         except Exception as exc:
             self.logger.exception("Failed to add SSH key: %s", exc)
             messagebox.showerror("Error", str(exc))
@@ -363,9 +363,6 @@ class SSHKeyManager:
             self.key_table.item(
                 item_id,
                 values=(updated["name"], updated.get("description", "")),
-            )
-            messagebox.showinfo(
-                "Success", f"SSH key '{updated['name']}' updated"
             )
             self.logger.info("SSH key '%s' updated", updated["name"])
         except Exception as exc:

--- a/tests/test_ssh_key_manager_ui.py
+++ b/tests/test_ssh_key_manager_ui.py
@@ -93,3 +93,175 @@ def test_manager_uses_table_and_double_click(monkeypatch) -> None:
     manager._on_edit = lambda: calls.append(True)
     bindings["<Double-1>"](None)
     assert calls
+
+
+def test_add_key_skips_success_popup(monkeypatch) -> None:
+    """Adding a key should not display a success message box."""
+    cfg = _load_cfg()
+    inserted: list = []
+
+    class DummyTreeview:
+        def __init__(self, *_, **__):
+            self.items = {}
+        def heading(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+        def insert(self, parent, index, values=()):
+            self.items["item1"] = {"values": values}
+            inserted.append(values)
+        def bind(self, *_, **__):
+            pass
+        def selection(self):
+            return ()
+        def item(self, item_id, **kwargs):
+            return self.items.get(item_id, {"values": ()})
+        def delete(self, item_id):
+            self.items.pop(item_id, None)
+
+    class DummyButton:
+        def __init__(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+
+    class DummyToplevel:
+        def __init__(self, *_, **__):
+            pass
+        def title(self, *_, **__):
+            pass
+        def geometry(self, *_, **__):
+            pass
+
+    fake_tk = SimpleNamespace(
+        Toplevel=DummyToplevel,
+        Button=DummyButton,
+        BOTH="both",
+        END="end",
+    )
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui, "load_ssh_keys", lambda: [])
+
+    class DummyDialog:
+        def __init__(self, *_, **__):
+            self.result = (
+                cfg["key1"]["name"],
+                cfg["key1"]["filename"],
+                cfg["key1"]["description"],
+            )
+
+    monkeypatch.setattr(ui, "SSHKeyDialog", DummyDialog)
+
+    def fake_create(name, path, desc):
+        return {"name": name, "description": desc}
+
+    monkeypatch.setattr(ui, "create_ssh_key", fake_create)
+
+    called = {}
+
+    def fake_showinfo(*args, **kwargs):
+        called["showinfo"] = True
+
+    monkeypatch.setattr(ui.messagebox, "showinfo", fake_showinfo)
+
+    manager = ui.SSHKeyManager(None)
+    manager._on_add()
+
+    assert inserted
+    assert "showinfo" not in called
+
+
+def test_edit_key_skips_success_popup(monkeypatch) -> None:
+    """Editing a key should not display a success message box."""
+    cfg = _load_cfg()
+
+    class DummyTreeview:
+        def __init__(self, *_, **__):
+            self.items = {}
+            self.last_id = ""
+        def heading(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+        def insert(self, parent, index, values=()):
+            self.last_id = f"item{len(self.items)+1}"
+            self.items[self.last_id] = {"values": values}
+            return self.last_id
+        def bind(self, *_, **__):
+            pass
+        def selection(self):
+            return [self.last_id] if self.last_id else []
+        def item(self, item_id, **kwargs):
+            if "values" in kwargs:
+                self.items[item_id] = {"values": kwargs["values"]}
+            return self.items.get(item_id, {"values": ()})
+        def delete(self, item_id):
+            self.items.pop(item_id, None)
+
+    class DummyButton:
+        def __init__(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+
+    class DummyToplevel:
+        def __init__(self, *_, **__):
+            pass
+        def title(self, *_, **__):
+            pass
+        def geometry(self, *_, **__):
+            pass
+
+    fake_tk = SimpleNamespace(
+        Toplevel=DummyToplevel,
+        Button=DummyButton,
+        BOTH="both",
+        END="end",
+    )
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+
+    monkeypatch.setattr(
+        ui,
+        "load_ssh_keys",
+        lambda: [
+            {
+                "name": cfg["key1"]["name"],
+                "description": cfg["key1"]["description"],
+                "path": cfg["key1"]["filename"],
+            }
+        ],
+    )
+
+    class DummyDialog:
+        def __init__(self, *_, **__):
+            self.result = (
+                cfg["updated_key"]["name"],
+                cfg["updated_key"]["filename"],
+                cfg["updated_key"]["description"],
+            )
+
+    monkeypatch.setattr(ui, "SSHKeyDialog", DummyDialog)
+
+    def fake_update(original, new_name, path, desc):
+        return {"name": new_name, "description": desc}
+
+    monkeypatch.setattr(ui, "update_ssh_key", fake_update)
+
+    called = {}
+
+    def fake_showinfo(*args, **kwargs):
+        called["showinfo"] = True
+
+    monkeypatch.setattr(ui.messagebox, "showinfo", fake_showinfo)
+
+    manager = ui.SSHKeyManager(None)
+    manager._on_edit()
+
+    assert manager.key_table.item(manager.key_table.last_id)["values"][0] == cfg["updated_key"]["name"]
+    assert "showinfo" not in called


### PR DESCRIPTION
## Summary
- Avoid success popups when adding or editing SSH keys
- Log SSH key changes and keep user on key manager screen
- Add regression tests to ensure success dialogs are not shown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf5b15c4832493458d9cc3d99e71