### PR TITLE
Enable profile editing via double-click

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -450,6 +450,7 @@ class LighthouseApp:
         self.profile_list = tk.Listbox(profile_frame)
         self.profile_list.pack(fill=tk.BOTH, expand=True)
         self.profile_list.bind("<<ListboxSelect>>", self._on_profile_select)
+        self.profile_list.bind("<Double-1>", self._on_profile_double_click)
         new_profile_btn = tk.Button(
             profile_frame, text="New Profile", command=self._on_new_profile
         )
@@ -533,6 +534,11 @@ class LighthouseApp:
             index = selection[0]
             value = event.widget.get(index)
             self.logger.info("Profile selected: %s", value)
+
+    def _on_profile_double_click(self, event: tk.Event) -> None:  # pragma: no cover - GUI event
+        """Open the profile edit dialog when a profile is double-clicked."""
+        self.logger.info("Profile double-click event")
+        self._on_edit_profile()
 
     def _on_tunnel_select(self, event: tk.Event) -> None:
         """Handle tunnel selection event."""

--- a/tests/profile_list_events.ini
+++ b/tests/profile_list_events.ini
@@ -1,0 +1,2 @@
+[events]
+double_click = <Double-1>

--- a/tests/test_profile_double_click.py
+++ b/tests/test_profile_double_click.py
@@ -1,0 +1,101 @@
+"""Tests for profile list double-click behaviour."""
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load configuration for profile list events."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_list_events.ini"))
+    return cfg
+
+
+def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
+    """Double-clicking a profile should invoke the edit handler."""
+    cfg = _load_cfg()
+    bindings: dict = {}
+
+    class DummyListbox:
+        def __init__(self, *_, **__):
+            self.bindings = bindings
+        def pack(self, *_, **__):
+            pass
+        def bind(self, event, callback):
+            self.bindings[event] = callback
+        def curselection(self):
+            return (0,)
+        def get(self, index):
+            return "profile"
+        def delete(self, index):
+            pass
+        def insert(self, index, value):
+            pass
+
+    class DummyWidget:
+        def __init__(self, *_, **__):
+            pass
+        def grid(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+        def bind(self, *_, **__):
+            pass
+        def rowconfigure(self, *_, **__):
+            pass
+        def columnconfigure(self, *_, **__):
+            pass
+        def insert(self, *_, **__):
+            pass
+        def after(self, delay, callback, *args):
+            callback(*args)
+        def update_idletasks(self):
+            pass
+
+    class DummyPanedWindow(DummyWidget):
+        def add(self, child, **kwargs):
+            pass
+        def panes(self):
+            return []
+        def sash_coord(self, idx):
+            return (0, 0)
+        def sash_place(self, idx, x, y):
+            pass
+
+    class DummyButton(DummyWidget):
+        def __init__(self, *_, **__):
+            pass
+
+    fake_tk = SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        Listbox=DummyListbox,
+        Text=DummyWidget,
+        Button=DummyButton,
+        END="end",
+        HORIZONTAL="horizontal",
+        BOTH="both",
+        GROOVE="groove",
+    )
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: [])
+    monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
+    monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)
+
+    root = DummyWidget()
+    app = ui.LighthouseApp(root, cfg)
+
+    calls = []
+    app._on_edit_profile = lambda: calls.append(True)
+
+    event_name = cfg["events"]["double_click"]
+    assert event_name in bindings
+    bindings[event_name](None)
+    assert calls


### PR DESCRIPTION
## Summary
- open profile edit dialog when a profile entry is double-clicked
- cover double-click behaviour with dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c239b488832482ce0fe106efcb0b