### PR TITLE
Show profiles in table with local IP

### DIFF
--- a/tests/test_info_pane_layout.py
+++ b/tests/test_info_pane_layout.py
@@ -62,6 +62,10 @@ def test_info_frame_expands_with_window(monkeypatch):
         def panes(self):
             return self.children
 
+    class DummyTreeview(DummyWidget):
+        def heading(self, *_, **__):
+            pass
+
     fake_tk = types.SimpleNamespace(
         PanedWindow=DummyPanedWindow,
         Frame=DummyWidget,
@@ -73,8 +77,10 @@ def test_info_frame_expands_with_window(monkeypatch):
         BOTH="both",
         GROOVE="groove",
     )
+    fake_ttk = types.SimpleNamespace(Treeview=DummyTreeview)
 
     monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
     monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
 
     cfg = configparser.ConfigParser()

--- a/tests/test_profile_double_click.py
+++ b/tests/test_profile_double_click.py
@@ -22,21 +22,19 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     cfg = _load_cfg()
     bindings: dict = {}
 
-    class DummyListbox:
+    class DummyTreeview:
         def __init__(self, *_, **__):
             self.bindings = bindings
         def pack(self, *_, **__):
             pass
         def bind(self, event, callback):
             self.bindings[event] = callback
-        def curselection(self):
-            return (0,)
-        def get(self, index):
-            return "profile"
-        def delete(self, index):
+        def heading(self, *_, **__):
             pass
-        def insert(self, index, value):
-            pass
+        def selection(self):
+            return ("item0",)
+        def item(self, item_id, option=None):
+            return ("profile", "127.0.0.1")
 
     class DummyWidget:
         def __init__(self, *_, **__):
@@ -75,7 +73,7 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     fake_tk = SimpleNamespace(
         PanedWindow=DummyPanedWindow,
         Frame=DummyWidget,
-        Listbox=DummyListbox,
+        Listbox=DummyWidget,
         Text=DummyWidget,
         Button=DummyButton,
         END="end",
@@ -84,7 +82,9 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
         GROOVE="groove",
     )
 
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
     monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
     monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: [])
     monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
     monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)

--- a/tests/test_restore_pane_layout.py
+++ b/tests/test_restore_pane_layout.py
@@ -75,6 +75,10 @@ def test_restore_pane_layout_after_panes(monkeypatch):
                 raise ValueError("sash index out of range")
             self.sashes[idx] = (x, y)
 
+    class DummyTreeview(DummyWidget):
+        def heading(self, *_, **__):
+            pass
+
     fake_tk = types.SimpleNamespace(
         PanedWindow=DummyPanedWindow,
         Frame=DummyWidget,
@@ -86,8 +90,10 @@ def test_restore_pane_layout_after_panes(monkeypatch):
         BOTH="both",
         GROOVE="groove",
     )
+    fake_ttk = types.SimpleNamespace(Treeview=DummyTreeview)
 
     monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
     monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: coords)
 
     class DummyRoot(DummyWidget):

--- a/tests/test_ui_buttons.py
+++ b/tests/test_ui_buttons.py
@@ -64,6 +64,10 @@ def test_buttons_labels(monkeypatch) -> None:
         def add(self, child, **kwargs):
             pass
 
+    class DummyTreeview(DummyWidget):
+        def heading(self, *_, **__):
+            pass
+
     fake_tk = SimpleNamespace(
         PanedWindow=DummyPanedWindow,
         Frame=DummyWidget,
@@ -75,8 +79,10 @@ def test_buttons_labels(monkeypatch) -> None:
         BOTH="both",
         GROOVE="groove",
     )
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
 
     monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
     monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: [])
     monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
     monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)


### PR DESCRIPTION
## Summary
- render profiles in a two-column table showing name and local IP address
- adjust profile handlers to work with the table and log selections
- update tests for new table-based profile view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c410ac7c83248cab45533f8dd95e