### PR TITLE
Ensure profile table columns respect container width

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -455,9 +455,14 @@ class LighthouseApp:
         # Human friendly column headings
         self.profile_list.heading("name", text="Name")
         self.profile_list.heading("ip", text="Local IP Address")
+        # Ensure columns resize with the containing widget
+        self.profile_list.column("name", anchor="w", stretch=True)
+        self.profile_list.column("ip", anchor="w", stretch=True)
         self.profile_list.pack(fill=tk.BOTH, expand=True)
         self.profile_list.bind("<<TreeviewSelect>>", self._on_profile_select)
         self.profile_list.bind("<Double-1>", self._on_profile_double_click)
+        # Adjust column widths whenever the widget size changes
+        self.profile_list.bind("<Configure>", self._on_profile_list_configure)
         new_profile_btn = tk.Button(
             profile_frame, text="New Profile", command=self._on_new_profile
         )
@@ -548,6 +553,23 @@ class LighthouseApp:
         """Open the profile edit dialog when a profile is double-clicked."""
         self.logger.info("Profile double-click event")
         self._on_edit_profile()
+
+    def _on_profile_list_configure(self, event: tk.Event) -> None:
+        """Resize profile list columns to fit available width."""
+        try:
+            total_width = max(getattr(event, "width", 0), 1)
+            name_width = total_width // 2
+            ip_width = total_width - name_width
+            self.profile_list.column("name", width=name_width)
+            self.profile_list.column("ip", width=ip_width)
+            self.logger.info(
+                "Profile list resized to %s px: name=%s, ip=%s",
+                total_width,
+                name_width,
+                ip_width,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.exception("Failed to resize profile list: %s", exc)
 
     def _on_tunnel_select(self, event: tk.Event) -> None:
         """Handle tunnel selection event."""

--- a/tests/profile_columns.ini
+++ b/tests/profile_columns.ini
@@ -1,0 +1,4 @@
+[profile_list]
+total_width = 200
+name_ratio = 0.5
+ip_ratio = 0.5

--- a/tests/test_info_pane_layout.py
+++ b/tests/test_info_pane_layout.py
@@ -63,8 +63,17 @@ def test_info_frame_expands_with_window(monkeypatch):
             return self.children
 
     class DummyTreeview(DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.columns = {}
+
         def heading(self, *_, **__):
             pass
+
+        def column(self, name, width=None, **_):
+            if width is not None:
+                self.columns[name] = width
+            return self.columns.get(name, 0)
 
     fake_tk = types.SimpleNamespace(
         PanedWindow=DummyPanedWindow,

--- a/tests/test_profile_double_click.py
+++ b/tests/test_profile_double_click.py
@@ -25,12 +25,17 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     class DummyTreeview:
         def __init__(self, *_, **__):
             self.bindings = bindings
+            self.columns = {}
         def pack(self, *_, **__):
             pass
         def bind(self, event, callback):
             self.bindings[event] = callback
         def heading(self, *_, **__):
             pass
+        def column(self, name, width=None, **_):
+            if width is not None:
+                self.columns[name] = width
+            return self.columns.get(name, 0)
         def selection(self):
             return ("item0",)
         def item(self, item_id, option=None):

--- a/tests/test_profile_list_resize.py
+++ b/tests/test_profile_list_resize.py
@@ -1,0 +1,49 @@
+"""Tests ensuring profile list columns stay within container width."""
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load configuration for profile list sizing tests."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_columns.ini"))
+    return cfg
+
+
+def test_profile_list_columns_fit_container() -> None:
+    """Columns should match container width based on predefined ratios."""
+    cfg = _load_cfg()
+    root = object()
+    with patch.object(ui.LighthouseApp, "_setup_logging", lambda self: None), \
+         patch.object(ui.LighthouseApp, "_build_ui", lambda self: None):
+        app = ui.LighthouseApp(root, cfg)
+
+    class DummyTreeview:
+        def __init__(self):
+            self.widths = {}
+        def column(self, col, width=None, **_):
+            if width is not None:
+                self.widths[col] = width
+            return self.widths.get(col, 0)
+    app.profile_list = DummyTreeview()
+
+    total_width = cfg.getint("profile_list", "total_width")
+    event = SimpleNamespace(width=total_width)
+    app._on_profile_list_configure(event)
+
+    name_ratio = cfg.getfloat("profile_list", "name_ratio")
+    ip_ratio = cfg.getfloat("profile_list", "ip_ratio")
+    expected_name = int(total_width * name_ratio)
+    expected_ip = int(total_width * ip_ratio)
+
+    assert app.profile_list.widths["name"] == expected_name
+    assert app.profile_list.widths["ip"] == expected_ip
+    assert app.profile_list.widths["name"] + app.profile_list.widths["ip"] == total_width

--- a/tests/test_restore_pane_layout.py
+++ b/tests/test_restore_pane_layout.py
@@ -76,8 +76,17 @@ def test_restore_pane_layout_after_panes(monkeypatch):
             self.sashes[idx] = (x, y)
 
     class DummyTreeview(DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.columns = {}
+
         def heading(self, *_, **__):
             pass
+
+        def column(self, name, width=None, **_):
+            if width is not None:
+                self.columns[name] = width
+            return self.columns.get(name, 0)
 
     fake_tk = types.SimpleNamespace(
         PanedWindow=DummyPanedWindow,

--- a/tests/test_ui_buttons.py
+++ b/tests/test_ui_buttons.py
@@ -65,8 +65,17 @@ def test_buttons_labels(monkeypatch) -> None:
             pass
 
     class DummyTreeview(DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.columns = {}
+
         def heading(self, *_, **__):
             pass
+
+        def column(self, name, width=None, **_):
+            if width is not None:
+                self.columns[name] = width
+            return self.columns.get(name, 0)
 
     fake_tk = SimpleNamespace(
         PanedWindow=DummyPanedWindow,


### PR DESCRIPTION
## Summary
- allow profile list columns to stretch and resize with the container
- handle profile list `<Configure>` events to recalc column widths with logging
- test column resizing based on configuration values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c5b3da9883249464b417325b2c44