### PR TITLE
feat: manage ssh tunnels in profiles

### DIFF
--- a/tests/profile_tunnels_test_config.ini
+++ b/tests/profile_tunnels_test_config.ini
@@ -1,0 +1,15 @@
+[profile]
+name = Alice
+ssh_key_filename = id_rsa_alice
+
+[tunnel]
+name = web
+local_port = 8000
+remote_host = example.com
+remote_port = 80
+
+[updated_tunnel]
+name = web_updated
+local_port = 8080
+remote_host = example.org
+remote_port = 8081

--- a/tests/test_profile_tunnels.py
+++ b/tests/test_profile_tunnels.py
@@ -1,0 +1,110 @@
+"""Tests for SSH tunnel management within profiles."""
+import configparser
+from pathlib import Path
+import sys
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app.profiles import (
+    create_profile,
+    add_tunnel,
+    update_tunnel,
+    delete_tunnel,
+    load_profiles,
+    PROFILES_FILE,
+)
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_tunnels_test_config.ini"))
+    return cfg
+
+
+def test_add_tunnel_and_storage(tmp_path):
+    cfg = _load_cfg()
+    profiles_file = tmp_path / PROFILES_FILE
+
+    key = tmp_path / cfg["profile"]["ssh_key_filename"]
+    key.touch()
+    create_profile(cfg["profile"]["name"], key, file_path=profiles_file)
+
+    add_tunnel(
+        cfg["profile"]["name"],
+        cfg["tunnel"]["name"],
+        int(cfg["tunnel"]["local_port"]),
+        cfg["tunnel"]["remote_host"],
+        int(cfg["tunnel"]["remote_port"]),
+        file_path=profiles_file,
+    )
+
+    stored = load_profiles(profiles_file)
+    tunnels = stored[0].get("tunnels", [])
+    assert len(tunnels) == 1
+    t = tunnels[0]
+    assert t["name"] == cfg["tunnel"]["name"]
+    assert t["local_port"] == int(cfg["tunnel"]["local_port"])
+    assert t["remote_host"] == cfg["tunnel"]["remote_host"]
+    assert t["remote_port"] == int(cfg["tunnel"]["remote_port"])
+
+
+def test_update_existing_tunnel(tmp_path):
+    cfg = _load_cfg()
+    profiles_file = tmp_path / PROFILES_FILE
+
+    key = tmp_path / cfg["profile"]["ssh_key_filename"]
+    key.touch()
+    create_profile(cfg["profile"]["name"], key, file_path=profiles_file)
+
+    add_tunnel(
+        cfg["profile"]["name"],
+        cfg["tunnel"]["name"],
+        int(cfg["tunnel"]["local_port"]),
+        cfg["tunnel"]["remote_host"],
+        int(cfg["tunnel"]["remote_port"]),
+        file_path=profiles_file,
+    )
+
+    update_tunnel(
+        cfg["profile"]["name"],
+        cfg["tunnel"]["name"],
+        cfg["updated_tunnel"]["name"],
+        int(cfg["updated_tunnel"]["local_port"]),
+        cfg["updated_tunnel"]["remote_host"],
+        int(cfg["updated_tunnel"]["remote_port"]),
+        file_path=profiles_file,
+    )
+
+    stored = load_profiles(profiles_file)
+    t = stored[0]["tunnels"][0]
+    assert t["name"] == cfg["updated_tunnel"]["name"]
+    assert t["local_port"] == int(cfg["updated_tunnel"]["local_port"])
+    assert t["remote_host"] == cfg["updated_tunnel"]["remote_host"]
+    assert t["remote_port"] == int(cfg["updated_tunnel"]["remote_port"])
+
+
+def test_delete_tunnel(tmp_path):
+    cfg = _load_cfg()
+    profiles_file = tmp_path / PROFILES_FILE
+
+    key = tmp_path / cfg["profile"]["ssh_key_filename"]
+    key.touch()
+    create_profile(cfg["profile"]["name"], key, file_path=profiles_file)
+
+    add_tunnel(
+        cfg["profile"]["name"],
+        cfg["tunnel"]["name"],
+        int(cfg["tunnel"]["local_port"]),
+        cfg["tunnel"]["remote_host"],
+        int(cfg["tunnel"]["remote_port"]),
+        file_path=profiles_file,
+    )
+
+    removed = delete_tunnel(
+        cfg["profile"]["name"], cfg["tunnel"]["name"], file_path=profiles_file
+    )
+    assert removed is True
+
+    stored = load_profiles(profiles_file)
+    assert stored[0].get("tunnels", []) == []


### PR DESCRIPTION
## Summary
- support adding, updating and removing SSH tunnels for a profile
- persist tunnel parameters in `profiles.json`
- test tunnel operations with configuration-driven data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ccbead6883248d981f22582af6e9