### PR TITLE
feat: support optional DNS name for tunnels

### DIFF
--- a/lighthouse_app/profiles.py
+++ b/lighthouse_app/profiles.py
@@ -215,6 +215,7 @@ def add_tunnel(
     local_port: int,
     remote_host: str,
     remote_port: int,
+    dns_name: str = "",
     file_path: Union[str, Path] = PROFILES_FILE,
 ) -> Dict[str, Union[str, int]]:
     """Create and attach an SSH tunnel to a profile.
@@ -231,12 +232,18 @@ def add_tunnel(
         Remote host to connect to.
     remote_port: int
         Remote port to connect to.
+    dns_name: str, optional
+        DNS name associated with the tunnel. Can be an empty string.
     file_path: str | Path, optional
         Path to the profiles JSON file. Defaults to ``PROFILES_FILE``.
     """
     logger = logging.getLogger(__name__)
+    dns_name = "" if dns_name is None else str(dns_name).strip()
     logger.info(
-        "Request to add tunnel '%s' to profile '%s'", tunnel_name, profile_name
+        "Request to add tunnel '%s' to profile '%s' with DNS name '%s'",
+        tunnel_name,
+        profile_name,
+        dns_name,
     )
 
     if not profile_name or not tunnel_name:
@@ -272,6 +279,7 @@ def add_tunnel(
         "local_port": l_port,
         "remote_host": remote_host,
         "remote_port": r_port,
+        "dns_name": dns_name,
     }
     tunnels.append(tunnel)
     save_profiles(profiles, file_path)
@@ -286,12 +294,37 @@ def update_tunnel(
     local_port: int,
     remote_host: str,
     remote_port: int,
+    dns_name: str = "",
     file_path: Union[str, Path] = PROFILES_FILE,
 ) -> Dict[str, Union[str, int]]:
-    """Update parameters of an existing SSH tunnel."""
+    """Update parameters of an existing SSH tunnel.
+
+    Parameters
+    ----------
+    profile_name: str
+        Name of the profile to modify.
+    tunnel_name: str
+        Current name of the tunnel to update.
+    new_name: str
+        New unique name for the tunnel.
+    local_port: int
+        Local port for the tunnel.
+    remote_host: str
+        Remote host to connect to.
+    remote_port: int
+        Remote port to connect to.
+    dns_name: str, optional
+        DNS name associated with the tunnel. Can be an empty string.
+    file_path: str | Path, optional
+        Path to the profiles JSON file. Defaults to ``PROFILES_FILE``.
+    """
     logger = logging.getLogger(__name__)
+    dns_name = "" if dns_name is None else str(dns_name).strip()
     logger.info(
-        "Request to update tunnel '%s' in profile '%s'", tunnel_name, profile_name
+        "Request to update tunnel '%s' in profile '%s' with DNS name '%s'",
+        tunnel_name,
+        profile_name,
+        dns_name,
     )
 
     if not profile_name or not new_name or not tunnel_name:
@@ -337,6 +370,7 @@ def update_tunnel(
             "local_port": l_port,
             "remote_host": remote_host,
             "remote_port": r_port,
+            "dns_name": dns_name,
         }
     )
     save_profiles(profiles, file_path)

--- a/tests/profile_tunnels_test_config.ini
+++ b/tests/profile_tunnels_test_config.ini
@@ -7,9 +7,18 @@ name = web
 local_port = 8000
 remote_host = example.com
 remote_port = 80
+dns_name = service.example.com
 
 [updated_tunnel]
 name = web_updated
 local_port = 8080
 remote_host = example.org
 remote_port = 8081
+dns_name = service-upd.example.org
+
+[no_dns_tunnel]
+name = nodns
+local_port = 9000
+remote_host = nodns.example.com
+remote_port = 9001
+dns_name = 

--- a/tests/test_profile_tunnels.py
+++ b/tests/test_profile_tunnels.py
@@ -36,6 +36,7 @@ def test_add_tunnel_and_storage(tmp_path):
         int(cfg["tunnel"]["local_port"]),
         cfg["tunnel"]["remote_host"],
         int(cfg["tunnel"]["remote_port"]),
+        cfg["tunnel"]["dns_name"],
         file_path=profiles_file,
     )
 
@@ -47,6 +48,31 @@ def test_add_tunnel_and_storage(tmp_path):
     assert t["local_port"] == int(cfg["tunnel"]["local_port"])
     assert t["remote_host"] == cfg["tunnel"]["remote_host"]
     assert t["remote_port"] == int(cfg["tunnel"]["remote_port"])
+    assert t["dns_name"] == cfg["tunnel"]["dns_name"]
+
+
+def test_add_tunnel_without_dns_name(tmp_path):
+    cfg = _load_cfg()
+    profiles_file = tmp_path / PROFILES_FILE
+
+    key = tmp_path / cfg["profile"]["ssh_key_filename"]
+    key.touch()
+    create_profile(cfg["profile"]["name"], key, file_path=profiles_file)
+
+    add_tunnel(
+        cfg["profile"]["name"],
+        cfg["no_dns_tunnel"]["name"],
+        int(cfg["no_dns_tunnel"]["local_port"]),
+        cfg["no_dns_tunnel"]["remote_host"],
+        int(cfg["no_dns_tunnel"]["remote_port"]),
+        file_path=profiles_file,
+    )
+
+    stored = load_profiles(profiles_file)
+    tunnels = stored[0].get("tunnels", [])
+    assert len(tunnels) == 1
+    t = tunnels[0]
+    assert t["dns_name"] == cfg["no_dns_tunnel"]["dns_name"]
 
 
 def test_update_existing_tunnel(tmp_path):
@@ -63,6 +89,7 @@ def test_update_existing_tunnel(tmp_path):
         int(cfg["tunnel"]["local_port"]),
         cfg["tunnel"]["remote_host"],
         int(cfg["tunnel"]["remote_port"]),
+        cfg["tunnel"]["dns_name"],
         file_path=profiles_file,
     )
 
@@ -73,6 +100,7 @@ def test_update_existing_tunnel(tmp_path):
         int(cfg["updated_tunnel"]["local_port"]),
         cfg["updated_tunnel"]["remote_host"],
         int(cfg["updated_tunnel"]["remote_port"]),
+        cfg["updated_tunnel"]["dns_name"],
         file_path=profiles_file,
     )
 
@@ -82,6 +110,7 @@ def test_update_existing_tunnel(tmp_path):
     assert t["local_port"] == int(cfg["updated_tunnel"]["local_port"])
     assert t["remote_host"] == cfg["updated_tunnel"]["remote_host"]
     assert t["remote_port"] == int(cfg["updated_tunnel"]["remote_port"])
+    assert t["dns_name"] == cfg["updated_tunnel"]["dns_name"]
 
 
 def test_delete_tunnel(tmp_path):
@@ -98,6 +127,7 @@ def test_delete_tunnel(tmp_path):
         int(cfg["tunnel"]["local_port"]),
         cfg["tunnel"]["remote_host"],
         int(cfg["tunnel"]["remote_port"]),
+        cfg["tunnel"]["dns_name"],
         file_path=profiles_file,
     )
 


### PR DESCRIPTION
## Summary
- allow SSH tunnels to store optional DNS name
- extend profile tunnel tests for DNS name handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0041c50832495c94f055d5d2c0a