### PR TITLE
Enable tunnel edit on double-click

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -622,6 +622,7 @@ class LighthouseApp:
         self.tunnel_list = tk.Listbox(tunnel_frame)
         self.tunnel_list.pack(fill=tk.BOTH, expand=True)
         self.tunnel_list.bind("<<ListboxSelect>>", self._on_tunnel_select)
+        self.tunnel_list.bind("<Double-1>", self._on_tunnel_double_click)
         new_tunnel_btn = tk.Button(
             tunnel_frame, text="New Tunnel", command=self._on_new_tunnel
         )
@@ -729,6 +730,11 @@ class LighthouseApp:
             index = selection[0]
             value = event.widget.get(index)
             self.logger.info("Tunnel selected: %s", value)
+
+    def _on_tunnel_double_click(self, event: tk.Event) -> None:  # pragma: no cover - GUI event
+        """Open the tunnel edit dialog when a tunnel is double-clicked."""
+        self.logger.info("Tunnel double-click event")
+        self._on_edit_tunnel()
 
     def _load_tunnels(self, profile_name: str) -> None:
         """Populate the tunnel list for the given profile."""

--- a/tests/test_tunnel_double_click.py
+++ b/tests/test_tunnel_double_click.py
@@ -1,0 +1,110 @@
+"""Tests for tunnel list double-click behaviour."""
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load configuration for tunnel list events."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("tunnel_list_events.ini"))
+    return cfg
+
+
+def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
+    """Double-clicking a tunnel should invoke the edit handler."""
+    cfg = _load_cfg()
+    bindings: dict = {}
+
+    class DummyTreeview:
+        def __init__(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+        def bind(self, *_, **__):
+            pass
+        def heading(self, *_, **__):
+            pass
+        def column(self, *_, **__):
+            return 0
+        def selection(self):
+            return ()
+        def item(self, *_, **__):
+            return ()
+
+    class DummyListbox:
+        def __init__(self, *_, **__):
+            self.bindings = bindings
+        def pack(self, *_, **__):
+            pass
+        def bind(self, event, callback):
+            self.bindings[event] = callback
+
+    class DummyWidget:
+        def __init__(self, *_, **__):
+            pass
+        def grid(self, *_, **__):
+            pass
+        def pack(self, *_, **__):
+            pass
+        def bind(self, *_, **__):
+            pass
+        def rowconfigure(self, *_, **__):
+            pass
+        def columnconfigure(self, *_, **__):
+            pass
+        def insert(self, *_, **__):
+            pass
+        def after(self, delay, callback, *args):
+            callback(*args)
+        def update_idletasks(self):
+            pass
+
+    class DummyPanedWindow(DummyWidget):
+        def add(self, child, **kwargs):
+            pass
+        def panes(self):
+            return []
+        def sash_coord(self, idx):
+            return (0, 0)
+        def sash_place(self, idx, x, y):
+            pass
+
+    class DummyButton(DummyWidget):
+        pass
+
+    fake_tk = SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        Listbox=DummyListbox,
+        Text=DummyWidget,
+        Button=DummyButton,
+        END="end",
+        HORIZONTAL="horizontal",
+        BOTH="both",
+        GROOVE="groove",
+    )
+
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: [])
+    monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
+    monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)
+
+    root = DummyWidget()
+    app = ui.LighthouseApp(root, cfg)
+
+    calls = []
+    app._on_edit_tunnel = lambda: calls.append(True)
+
+    event_name = cfg["events"]["double_click"]
+    assert event_name in bindings
+    bindings[event_name](None)
+    assert calls

--- a/tests/tunnel_list_events.ini
+++ b/tests/tunnel_list_events.ini
@@ -1,0 +1,2 @@
+[events]
+double_click = <Double-1>


### PR DESCRIPTION
## Summary
- open tunnel edit dialog when double-clicking an entry
- cover tunnel double-click behaviour with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5d256b9288324a1474199c6ae8005