### PR TITLE
Add tabular view for SSH tunnels

### DIFF
--- a/tests/test_profile_double_click.py
+++ b/tests/test_profile_double_click.py
@@ -20,11 +20,10 @@ def _load_cfg() -> configparser.ConfigParser:
 def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     """Double-clicking a profile should invoke the edit handler."""
     cfg = _load_cfg()
-    bindings: dict = {}
 
     class DummyTreeview:
         def __init__(self, *_, **__):
-            self.bindings = bindings
+            self.bindings = {}
             self.columns = {}
         def pack(self, *_, **__):
             pass
@@ -101,6 +100,6 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     app._on_edit_profile = lambda: calls.append(True)
 
     event_name = cfg["events"]["double_click"]
-    assert event_name in bindings
-    bindings[event_name](None)
+    assert event_name in app.profile_list.bindings
+    app.profile_list.bindings[event_name](None)
     assert calls

--- a/tests/test_tunnel_double_click.py
+++ b/tests/test_tunnel_double_click.py
@@ -20,15 +20,14 @@ def _load_cfg() -> configparser.ConfigParser:
 def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
     """Double-clicking a tunnel should invoke the edit handler."""
     cfg = _load_cfg()
-    bindings: dict = {}
 
     class DummyTreeview:
         def __init__(self, *_, **__):
-            pass
+            self.bindings = {}
         def pack(self, *_, **__):
             pass
-        def bind(self, *_, **__):
-            pass
+        def bind(self, event, callback):
+            self.bindings[event] = callback
         def heading(self, *_, **__):
             pass
         def column(self, *_, **__):
@@ -37,14 +36,6 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
             return ()
         def item(self, *_, **__):
             return ()
-
-    class DummyListbox:
-        def __init__(self, *_, **__):
-            self.bindings = bindings
-        def pack(self, *_, **__):
-            pass
-        def bind(self, event, callback):
-            self.bindings[event] = callback
 
     class DummyWidget:
         def __init__(self, *_, **__):
@@ -82,7 +73,7 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
     fake_tk = SimpleNamespace(
         PanedWindow=DummyPanedWindow,
         Frame=DummyWidget,
-        Listbox=DummyListbox,
+        Listbox=DummyWidget,
         Text=DummyWidget,
         Button=DummyButton,
         END="end",
@@ -105,6 +96,6 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
     app._on_edit_tunnel = lambda: calls.append(True)
 
     event_name = cfg["events"]["double_click"]
-    assert event_name in bindings
-    bindings[event_name](None)
+    assert event_name in app.tunnel_list.bindings
+    app.tunnel_list.bindings[event_name](None)
     assert calls


### PR DESCRIPTION
## Summary
- show SSH tunnels in a two-column table listing name and remote target
- handle tunnel selection, edit, and delete for the new table
- adjust tests for updated tunnel UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d394cac4832492746b6b996403b2