### PR TITLE
Ensure SSH tunnel columns resize with container

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -632,6 +632,8 @@ class LighthouseApp:
         self.tunnel_list.pack(fill=tk.BOTH, expand=True)
         self.tunnel_list.bind("<<TreeviewSelect>>", self._on_tunnel_select)
         self.tunnel_list.bind("<Double-1>", self._on_tunnel_double_click)
+        # Adjust column widths whenever the widget size changes
+        self.tunnel_list.bind("<Configure>", self._on_tunnel_list_configure)
         new_tunnel_btn = tk.Button(
             tunnel_frame, text="New Tunnel", command=self._on_new_tunnel
         )
@@ -731,6 +733,23 @@ class LighthouseApp:
             )
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.exception("Failed to resize profile list: %s", exc)
+
+    def _on_tunnel_list_configure(self, event: tk.Event) -> None:
+        """Resize tunnel list columns to fit available width."""
+        try:
+            total_width = max(getattr(event, "width", 0), 1)
+            name_width = total_width // 2
+            target_width = total_width - name_width
+            self.tunnel_list.column("name", width=name_width)
+            self.tunnel_list.column("target", width=target_width)
+            self.logger.info(
+                "Tunnel list resized to %s px: name=%s, target=%s",
+                total_width,
+                name_width,
+                target_width,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.exception("Failed to resize tunnel list: %s", exc)
 
     def _on_tunnel_select(self, event: tk.Event) -> None:
         """Handle tunnel selection event."""

--- a/tests/test_tunnel_list_resize.py
+++ b/tests/test_tunnel_list_resize.py
@@ -1,0 +1,49 @@
+"""Tests ensuring tunnel list columns stay within container width."""
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load configuration for tunnel list sizing tests."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("tunnel_columns.ini"))
+    return cfg
+
+
+def test_tunnel_list_columns_fit_container() -> None:
+    """Columns should match container width based on predefined ratios."""
+    cfg = _load_cfg()
+    root = object()
+    with patch.object(ui.LighthouseApp, "_setup_logging", lambda self: None), \
+         patch.object(ui.LighthouseApp, "_build_ui", lambda self: None):
+        app = ui.LighthouseApp(root, cfg)
+
+    class DummyTreeview:
+        def __init__(self):
+            self.widths = {}
+        def column(self, col, width=None, **_):
+            if width is not None:
+                self.widths[col] = width
+            return self.widths.get(col, 0)
+    app.tunnel_list = DummyTreeview()
+
+    total_width = cfg.getint("tunnel_list", "total_width")
+    event = SimpleNamespace(width=total_width)
+    app._on_tunnel_list_configure(event)
+
+    name_ratio = cfg.getfloat("tunnel_list", "name_ratio")
+    target_ratio = cfg.getfloat("tunnel_list", "target_ratio")
+    expected_name = int(total_width * name_ratio)
+    expected_target = int(total_width * target_ratio)
+
+    assert app.tunnel_list.widths["name"] == expected_name
+    assert app.tunnel_list.widths["target"] == expected_target
+    assert app.tunnel_list.widths["name"] + app.tunnel_list.widths["target"] == total_width

--- a/tests/tunnel_columns.ini
+++ b/tests/tunnel_columns.ini
@@ -1,0 +1,4 @@
+[tunnel_list]
+total_width = 200
+name_ratio = 0.5
+target_ratio = 0.5


### PR DESCRIPTION
## Summary
- Resize SSH tunnel list columns to match container width
- Test tunnel list column sizing logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5b75ed08324b019132ac52bbb93