### PR TITLE
feat: set default ssh port for new tunnels

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -373,6 +373,10 @@ class TunnelDialog(simpledialog.Dialog):
                 existing_dns = [self.tunnel.get("dns_name")]
             for dns in existing_dns:
                 self.dns_list.insert(tk.END, dns)
+        else:
+            # Fill SSH port with safe default for new tunnels
+            self.ssh_port_entry.insert(0, "22")
+            self.logger.info("Tunnel dialog: default SSH port 22 inserted")
 
         return self.name_entry
 

--- a/tests/profile_tunnels_test_config.ini
+++ b/tests/profile_tunnels_test_config.ini
@@ -32,3 +32,6 @@ remote_port = 9001
 dns_names =
 ssh_host = ssh.nodns.example.com
 username = nodns_user
+
+[defaults]
+ssh_port = 22

--- a/tests/test_tunnel_dialog_default_port.py
+++ b/tests/test_tunnel_dialog_default_port.py
@@ -1,0 +1,84 @@
+"""Tests for default SSH port in TunnelDialog."""
+import configparser
+from pathlib import Path
+import logging
+from types import SimpleNamespace
+import sys
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def test_tunnel_dialog_prefills_ssh_port(monkeypatch) -> None:
+    """New tunnel dialog should pre-fill SSH port from config."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_tunnels_test_config.ini"))
+    expected = cfg["defaults"].getint("ssh_port")
+
+    class DummyEntry:
+        def __init__(self, master=None):
+            self.value = ""
+        def grid(self, *_, **__):
+            pass
+        def insert(self, index, value):
+            self.value = value
+        def get(self):
+            return self.value
+        def configure(self, *_, **__):
+            pass
+
+    class DummyLabel:
+        def __init__(self, *_, **__):
+            pass
+        def grid(self, *_, **__):
+            pass
+
+    class DummyButton:
+        def __init__(self, *_, **__):
+            pass
+        def grid(self, *_, **__):
+            pass
+
+    class DummyFrame:
+        def __init__(self, *_, **__):
+            pass
+        def grid(self, *_, **__):
+            pass
+        def columnconfigure(self, *_, **__):
+            pass
+
+    class DummyListbox:
+        def __init__(self, *_, **__):
+            self.items = []
+        def grid(self, *_, **__):
+            pass
+        def insert(self, index, value):
+            self.items.append(value)
+        def get(self, start, end):
+            return self.items
+        def delete(self, start, end=None):
+            self.items.clear()
+
+    fake_tk = SimpleNamespace(
+        Label=DummyLabel,
+        Entry=DummyEntry,
+        Button=DummyButton,
+        Frame=DummyFrame,
+        Listbox=DummyListbox,
+        END="end",
+    )
+    monkeypatch.setattr(ui, "tk", fake_tk)
+
+    class DummyDialog(ui.TunnelDialog):
+        def __init__(self):
+            self.existing_tunnels = []
+            self.tunnel = None
+            self.dns_names = []
+            self.logger = logging.getLogger(__name__)
+
+    dialog = DummyDialog()
+    dialog.body(object())
+    assert dialog.ssh_port_entry.get() == str(expected)
+


### PR DESCRIPTION
## Summary
- prefill SSH port with 22 in the new tunnel dialog
- document default SSH port in test config and add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b66a9f13b88324917f3541a95df498