### PR TITLE
Show tunnel status instead of SSH command

### DIFF
--- a/tests/profile_tunnels_test_config.ini
+++ b/tests/profile_tunnels_test_config.ini
@@ -35,3 +35,7 @@ username = nodns_user
 
 [defaults]
 ssh_port = 22
+
+[expected]
+# Expected status for tunnels when no active forwarder is running
+tunnel_status = stopped

--- a/tests/test_tunnel_info_display.py
+++ b/tests/test_tunnel_info_display.py
@@ -101,15 +101,9 @@ def test_tunnel_selection_updates_status(monkeypatch) -> None:
     dns_list = [
         d.strip() for d in cfg["tunnel"]["dns_names"].split(",") if d.strip()
     ]
-    expected_cmd = (
-        f"ssh -i {cfg['profile']['ssh_dir']}/{cfg['profile']['ssh_key_filename']} "
-        f"-p {cfg['tunnel']['ssh_port']} "
-        f"-L {cfg['tunnel']['local_port']}:{cfg['tunnel']['remote_host']}:{cfg['tunnel']['remote_port']} "
-        f"{cfg['tunnel']['username']}@{cfg['tunnel']['ssh_host']}"
-    )
     expected_text = (
         f"Tunnel: {cfg['tunnel']['name']}\n"
-        f"Command: {expected_cmd}\n"
+        f"Status: {cfg['expected']['tunnel_status']}\n"
         f"DNS: {', '.join(dns_list)}"
     )
 


### PR DESCRIPTION
## Summary
- replace SSH command in tunnel info pane with live tunnel status
- refresh status pane when tunnels start or stop
- update tests and config for status display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67732ae248324bae467496128061b