### PR TITLE
Add profile loading to service layer and expose active tunnel mapping

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -11,6 +11,25 @@ import paramiko
 from sshtunnel import SSHTunnelForwarder, DEFAULT_SSH_DIRECTORY
 
 from .hosts import add_hosts_block, remove_hosts_block
+from .profiles import PROFILES_FILE, load_profiles as _load_profiles
+
+
+def load_profiles(file_path: Union[str, Path] = PROFILES_FILE) -> List[Dict[str, str]]:
+    """Load profile definitions for the UI layer.
+
+    This helper retains a simple API that tests can monkeypatch while
+    delegating the actual work to :mod:`lighthouse_app.profiles`.
+    Any unexpected error is logged and results in an empty list.
+    """
+    logger = logging.getLogger(__name__)
+    logger.debug("UI request to load profiles from %s", file_path)
+    try:
+        profiles = _load_profiles(file_path)
+        logger.debug("UI loaded %d profiles", len(profiles))
+        return profiles
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("UI failed to load profiles: %s", exc)
+        return []
 
 
 def _safe_read_private_key_file(

--- a/tests/test_profile_controller.py
+++ b/tests/test_profile_controller.py
@@ -5,6 +5,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from lighthouse_app.controllers.profile_controller import ProfileController
+from lighthouse_app.profiles import PROFILES_FILE
 
 
 def _load_cfg() -> configparser.ConfigParser:
@@ -27,3 +28,19 @@ def test_controller_delegates_to_service(monkeypatch):
     result = controller.create_profile(cfg["profile1"]["name"], key_path)
     assert result["name"] == cfg["profile1"]["name"]
     assert called["args"][0] == cfg["profile1"]["name"]
+
+
+def test_load_profiles_delegates_to_service(monkeypatch):
+    cfg = _load_cfg()
+    controller = ProfileController()
+    expected = [{"name": cfg["profile1"]["name"]}]
+    called = {}
+
+    def fake_load(file_path=PROFILES_FILE):
+        called["file_path"] = file_path
+        return expected
+
+    monkeypatch.setattr(controller.service, "load_profiles", fake_load)
+    result = controller.load_profiles()
+    assert result == expected
+    assert called["file_path"] == PROFILES_FILE


### PR DESCRIPTION
## Summary
- add `load_profiles` method in `ProfileService` and use it across the service
- expose `active_tunnels` property via `ProfileController` and pass loaded profiles when starting tunnels
- provide `load_profiles` helper in UI module for backward compatibility
- test controller delegation for profile loading

## Testing
- `pytest tests/test_profile_controller.py tests/test_active_highlight.py -q`
- `pytest -q` *(fails: test_tunnel_info_display.py::test_tunnel_selection_updates_status, test_tunnel_log.py::test_start_tunnel_appends_log, test_tunnel_start_stop.py::test_start_tunnel_invokes_forwarder, tests/test_tunnel_ui.py::test_new_tunnel_skips_success_popup, tests/test_tunnel_ui.py::test_edit_tunnel_skips_success_popup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a9dfcd148324a25e01f9cca3e4d8