### PR TITLE
Fix tunnel operations and enable testing

### DIFF
--- a/lighthouse_app/controllers/profile_controller.py
+++ b/lighthouse_app/controllers/profile_controller.py
@@ -121,9 +121,19 @@ class ProfileController:
         profile_name: str,
         tunnel_name: str,
         file_path: Union[str, Path] = PROFILES_FILE,
+        profiles: Optional[List[Dict[str, str]]] = None,
+        forwarder_cls: type[SSHTunnelForwarder] = SSHTunnelForwarder,
     ) -> None:
-        profiles = self.load_profiles()
-        self.service.start_tunnel(profile_name, tunnel_name, file_path, profiles)
+        """Start the given tunnel, optionally using preloaded profiles."""
+        if profiles is None:
+            profiles = self.load_profiles(file_path)
+        self.service.start_tunnel(
+            profile_name,
+            tunnel_name,
+            file_path,
+            profiles,
+            forwarder_cls,
+        )
 
     def stop_tunnel(self, profile_name: str, tunnel_name: str) -> None:
         self.service.stop_tunnel(profile_name, tunnel_name)

--- a/lighthouse_app/services/profile_service.py
+++ b/lighthouse_app/services/profile_service.py
@@ -229,6 +229,7 @@ class ProfileService:
         tunnel_name: str,
         file_path: Union[str, Path] = PROFILES_FILE,
         profiles: Optional[List[Dict[str, str]]] = None,
+        forwarder_cls: type[SSHTunnelForwarder] = SSHTunnelForwarder,
     ) -> None:
         key = (profile_name, tunnel_name)
         forwarder = self.active_tunnels.get(key)
@@ -250,7 +251,7 @@ class ProfileService:
         bind_ip = profile.get("ip")
         if not bind_ip:
             raise ValueError(f"Profile '{profile_name}' has no IP address")
-        forwarder = SSHTunnelForwarder(
+        forwarder = forwarder_cls(
             ssh_address_or_host=(tunnel.get("ssh_host"), int(tunnel.get("ssh_port"))),
             ssh_username=tunnel.get("username"),
             ssh_pkey=profile.get("ssh_key"),


### PR DESCRIPTION
## Summary
- Make UI resilient without real Tk widgets and allow reuse in tests
- Load profiles directly in UI handlers and support flexible tunnel creation
- Allow controller/service to inject custom SSHTunnelForwarder for testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0e024d48324b283756dab760323