### PR TITLE
Detect system-specific hosts file path

### DIFF
--- a/lighthouse_app/controllers/profile_controller.py
+++ b/lighthouse_app/controllers/profile_controller.py
@@ -9,7 +9,8 @@ from ..services.profile_service import ProfileService
 class ProfileController:
     """Controller orchestrating profile and tunnel operations."""
 
-    def __init__(self, hosts_file: Union[str, Path] = "/etc/hosts") -> None:
+    def __init__(self, hosts_file: Optional[Union[str, Path]] = None) -> None:
+        """Initialise the controller with an optional hosts file path."""
         self.service = ProfileService(hosts_file)
 
     @property

--- a/lighthouse_app/hosts.py
+++ b/lighthouse_app/hosts.py
@@ -1,7 +1,29 @@
+"""Utilities for updating the system hosts file.
+
+The module also exposes a helper for resolving the default hosts file path
+depending on the operating system.  This keeps OS specific logic in a single
+place and allows other parts of the application to simply call
+``default_hosts_file`` when they need the location of the hosts file.
+"""
+
 import logging
+import platform
 from pathlib import Path
 from typing import List, Union
 
+
+def default_hosts_file() -> Path:
+    """Return the platform specific hosts file path.
+
+    Windows stores the file in the system directory while Unix like systems
+    use ``/etc/hosts``.  The function intentionally falls back to the Unix
+    path for unknown systems so that behaviour is predictable.
+    """
+
+    system = platform.system().lower()
+    if system == "windows":
+        return Path(r"C:\Windows\System32\drivers\etc\hosts")
+    return Path("/etc/hosts")
 
 def add_hosts_block(
     profile_name: str,

--- a/lighthouse_app/services/profile_service.py
+++ b/lighthouse_app/services/profile_service.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from sshtunnel import SSHTunnelForwarder
 
-from ..hosts import add_hosts_block, remove_hosts_block
+from ..hosts import add_hosts_block, remove_hosts_block, default_hosts_file
 from ..profiles import (
     PROFILES_FILE,
     _allocate_ip,
@@ -16,11 +16,25 @@ from ..profiles import (
 class ProfileService:
     """Service layer encapsulating profile and tunnel operations."""
 
-    def __init__(self, hosts_file: Union[str, Path] = "/etc/hosts") -> None:
-        self.hosts_file = Path(hosts_file)
+    def __init__(self, hosts_file: Optional[Union[str, Path]] = None) -> None:
+        """Create the service using a platform specific hosts file.
+
+        Parameters
+        ----------
+        hosts_file: str | Path | None
+            Optional explicit path to the hosts file.  When ``None`` the
+            system specific default from :func:`lighthouse_app.hosts.default_hosts_file`
+            is used.
+        """
+
+        if hosts_file is None:
+            self.hosts_file = default_hosts_file()
+        else:
+            self.hosts_file = Path(hosts_file)
         # Track running tunnels; keys are ``(profile_name, tunnel_name)`` tuples
         self.active_tunnels: Dict[Tuple[str, str], SSHTunnelForwarder] = {}
         self.logger = logging.getLogger(__name__)
+        self.logger.debug("Using hosts file %s", self.hosts_file)
 
     # ------------------------------------------------------------------
     # Profile management

--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -12,7 +12,7 @@ from sshtunnel import SSHTunnelForwarder, DEFAULT_SSH_DIRECTORY
 
 _ORIGINAL_FORWARDER = SSHTunnelForwarder
 
-from .hosts import add_hosts_block, remove_hosts_block
+from .hosts import add_hosts_block, remove_hosts_block, default_hosts_file
 from .profiles import PROFILES_FILE, load_profiles as _load_profiles
 
 
@@ -760,8 +760,11 @@ class LighthouseApp:
         self.root = root
         self.cfg = cfg
         self.logger = logging.getLogger(__name__)
-        hosts_path = self.cfg.get("hosts", "file", fallback="/etc/hosts")
+        hosts_path = self.cfg.get(
+            "hosts", "file", fallback=str(default_hosts_file())
+        )
         self.hosts_file = Path(hosts_path)
+        self.logger.debug("Hosts file set to %s", self.hosts_file)
         self.profile_controller = ProfileController(self.hosts_file)
         self.key_controller = KeyController()
 

--- a/tests/hosts_path_test_config.ini
+++ b/tests/hosts_path_test_config.ini
@@ -1,0 +1,3 @@
+[hosts]
+linux = /etc/hosts
+windows = C:\Windows\System32\drivers\etc\hosts

--- a/tests/test_default_hosts_file.py
+++ b/tests/test_default_hosts_file.py
@@ -1,0 +1,30 @@
+"""Tests for resolving platform specific hosts file paths."""
+
+import configparser
+from pathlib import Path
+import platform
+import sys
+
+# Ensure the application package is importable during tests
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app.hosts import default_hosts_file
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load expected host paths from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("hosts_path_test_config.ini"))
+    return cfg
+
+
+def test_default_hosts_file_linux(monkeypatch):
+    cfg = _load_cfg()
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert str(default_hosts_file()) == cfg["hosts"]["linux"]
+
+
+def test_default_hosts_file_windows(monkeypatch):
+    cfg = _load_cfg()
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert str(default_hosts_file()) == cfg["hosts"]["windows"]


### PR DESCRIPTION
## Summary
- choose default hosts file based on operating system
- log selected hosts file and use it across services and UI
- test platform detection for hosts file paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b7880700832493e2ae2980bfc559