### PR TITLE
Fix imports in ui for package execution

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -12,8 +12,12 @@ from sshtunnel import SSHTunnelForwarder, DEFAULT_SSH_DIRECTORY
 
 _ORIGINAL_FORWARDER = SSHTunnelForwarder
 
-from .hosts import add_hosts_block, remove_hosts_block, default_hosts_file
-from .profiles import PROFILES_FILE, load_profiles as _load_profiles
+from lighthouse_app.hosts import (
+    add_hosts_block,
+    remove_hosts_block,
+    default_hosts_file,
+)
+from lighthouse_app.profiles import PROFILES_FILE, load_profiles as _load_profiles
 
 
 def load_profiles(file_path: Union[str, Path] = PROFILES_FILE) -> List[Dict[str, str]]:


### PR DESCRIPTION
## Summary
- use absolute imports for hosts and profiles modules in ui

## Testing
- `pytest -q`
- `python -m lighthouse_app.ui` (fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)


------
https://chatgpt.com/codex/tasks/task_e_68b6bdfb84d88324a8f5b541abeff536