### PR TITLE
Allow standalone execution in Windows build

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -1595,10 +1595,9 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    if __package__ in {None, ''}:
-        logging.error(
-            "This module must be executed as part of the lighthouse_app package.\n"
-            "Use 'python -m lighthouse_app.ui' instead."
-        )
-        raise SystemExit(1)
+    # When packaged with tools like PyInstaller the module may execute with
+    # ``__package__`` set to ``None``.  Previously this triggered an early
+    # exit which caused the frozen application to close immediately.  Running
+    # the entry point should be permitted regardless of how the module is
+    # invoked.
     main()


### PR DESCRIPTION
## Summary
- Allow running the UI module directly by removing the strict package check
- Document rationale so frozen executables don't exit immediately

## Testing
- `pytest` (fails: 24 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b6e54539a483249f1f82dfe32f9acc