### PR TITLE
Логировать трассировки только в файл

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -806,6 +806,7 @@ class LighthouseApp:
                 logging.FileHandler("app.log"),
                 logging.StreamHandler(),
             ],
+            force=True,
         )
 
         class UILogHandler(logging.Handler):
@@ -817,7 +818,13 @@ class LighthouseApp:
 
             def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - UI safety
                 try:
+                    exc_info = record.exc_info
+                    exc_text = getattr(record, "exc_text", None)
+                    record.exc_info = None
+                    record.exc_text = None
                     message = self.format(record)
+                    record.exc_info = exc_info
+                    record.exc_text = exc_text
                     self.app._append_log(message)
                 except Exception:
                     # Logging failures should never crash the application


### PR DESCRIPTION
## Summary
- Возвратил `logger.exception` во всех обработчиках, чтобы трассировки сохранялись в файле логов
- В UI логи добавлен обработчик, убирающий стеки вызовов и принудительная настройка логирования
- Тесты проверяют, что `app.log` содержит Traceback, а окно логов только текст ошибки

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b713183e6c83248c42b5bd506486c4