### PR TITLE
feat(ui): use labeled frame for profile name input

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -261,9 +261,21 @@ class ProfileDialog(simpledialog.Dialog):
         return mapping
 
     def body(self, master: tk.Misc) -> tk.Entry:
-        tk.Label(master, text="Profile name:").grid(row=0, column=0, sticky="w")
-        self.name_entry = tk.Entry(master)
-        self.name_entry.grid(row=0, column=1)
+        """Construct dialog body with labelled input widgets.
+
+        The profile name field now mirrors the appearance of the main
+        window's *Status* container by using a ``LabelFrame``.  This
+        places the descriptive text in the frame's border with the entry
+        widget inside, making the label appear above the input field.
+        """
+
+        # Profile name container with border and caption above the entry
+        self.name_frame = tk.LabelFrame(master, text="Profile name")
+        self.name_frame.grid(row=0, column=0, columnspan=2, sticky="ew")
+        self.name_frame.columnconfigure(0, weight=1)
+        self.name_entry = tk.Entry(self.name_frame)
+        self.name_entry.grid(row=0, column=0, sticky="ew")
+        self.logger.debug("Profile name field prepared in labelled frame")
 
         tk.Label(master, text="SSH key:").grid(row=1, column=0, sticky="w")
         # Prepare drop-down of available SSH keys

--- a/tests/profile_name_label.ini
+++ b/tests/profile_name_label.ini
@@ -1,0 +1,2 @@
+[label]
+profile_name=Profile name

--- a/tests/test_profile_dialog_ssh_key_selection.py
+++ b/tests/test_profile_dialog_ssh_key_selection.py
@@ -40,6 +40,16 @@ def test_profile_dialog_uses_existing_keys(monkeypatch):
         def grid(self, *a, **k):
             pass
 
+    class DummyLabelFrame(DummyLabel):
+        def __init__(self, *a, text="", **k):
+            super().__init__(*a, **k)
+            self._text = text
+        def columnconfigure(self, *a, **k):
+            pass
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
     class DummyCombobox:
         def __init__(self, master=None, textvariable=None, state=""):
             self.textvariable = textvariable
@@ -71,6 +81,7 @@ def test_profile_dialog_uses_existing_keys(monkeypatch):
 
     fake_tk = SimpleNamespace(
         Label=DummyLabel,
+        LabelFrame=DummyLabelFrame,
         Entry=DummyEntry,
         Checkbutton=DummyCheckbutton,
         BooleanVar=DummyBooleanVar,

--- a/tests/test_profile_name_labelframe.py
+++ b/tests/test_profile_name_labelframe.py
@@ -1,0 +1,105 @@
+"""Ensure profile dialog uses a labeled frame for profile name."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import logging
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_label() -> str:
+    """Read expected profile name label from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_name_label.ini"))
+    return cfg["label"]["profile_name"]
+
+
+def test_profile_name_uses_labelframe(monkeypatch) -> None:
+    """Profile dialog should wrap name entry in a labeled frame."""
+    expected = _expected_label()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets."""
+
+        def __init__(self, *_, **__):
+            pass
+
+        def grid(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            pass
+
+        def rowconfigure(self, *_, **__):
+            pass
+
+        def columnconfigure(self, *_, **__):
+            pass
+
+        def insert(self, *_, **__):
+            pass
+
+        def configure(self, *_, **__):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *_, text="", **__):
+            super().__init__()
+            self._text = text
+
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
+    class DummyEntry(DummyWidget):
+        def __init__(self, *_, **__):
+            super().__init__()
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *_, textvariable=None, state=None, **__):
+            super().__init__()
+            self._values = []
+
+        def __setitem__(self, key, value):
+            if key == "values":
+                self._values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    dialog = ui.ProfileDialog.__new__(ui.ProfileDialog)
+    dialog.existing_profiles = []
+    dialog.profile = None
+    dialog.logger = logging.getLogger("test")
+
+    master = DummyWidget()
+    dialog.body(master)
+
+    assert isinstance(dialog.name_frame, DummyLabelFrame)
+    assert dialog.name_frame.cget("text") == expected


### PR DESCRIPTION
## Summary
- style profile creation dialog to place profile name entry inside a labeled frame
- cover new layout with tests and adjust existing profile dialog tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b718f0f6c88324973402040f95d22e