### PR TITLE
Group IP options in profile dialog

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -288,19 +288,25 @@ class ProfileDialog(simpledialog.Dialog):
         self.key_combo["values"] = list(self.key_map.keys())
         self.key_combo.grid(row=1, column=1)
 
+        # IP settings grouped for clarity
+        self.ip_frame = tk.LabelFrame(master, text="IP Settings")
+        self.ip_frame.grid(row=2, column=0, columnspan=2, sticky="ew")
+        self.ip_frame.columnconfigure(1, weight=1)
+        self.logger.debug("IP settings fields prepared in labelled frame")
+
         auto_default = True if self.profile is None else False
         self.auto_var = tk.BooleanVar(value=auto_default)
         auto_chk = tk.Checkbutton(
-            master,
+            self.ip_frame,
             text="Assign IP automatically",
             variable=self.auto_var,
             command=self._toggle_ip_entry,
         )
-        auto_chk.grid(row=2, column=0, columnspan=2, sticky="w")
+        auto_chk.grid(row=0, column=0, columnspan=2, sticky="w")
 
-        tk.Label(master, text="IP address:").grid(row=3, column=0, sticky="w")
-        self.ip_entry = tk.Entry(master)
-        self.ip_entry.grid(row=3, column=1)
+        tk.Label(self.ip_frame, text="IP address:").grid(row=1, column=0, sticky="w")
+        self.ip_entry = tk.Entry(self.ip_frame)
+        self.ip_entry.grid(row=1, column=1, sticky="ew")
         self.ip_entry.configure(state="disabled" if auto_default else "normal")
 
         if self.profile is not None:

--- a/tests/ip_settings_label.ini
+++ b/tests/ip_settings_label.ini
@@ -1,0 +1,3 @@
+[label]
+ip_settings=IP Settings
+

--- a/tests/test_ip_settings_labelframe.py
+++ b/tests/test_ip_settings_labelframe.py
@@ -1,0 +1,105 @@
+"""Ensure IP options in profile dialog are grouped in a labelled frame."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import logging
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_label() -> str:
+    """Read expected IP settings label from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("ip_settings_label.ini"))
+    return cfg["label"]["ip_settings"]
+
+
+def test_ip_settings_uses_labelframe(monkeypatch) -> None:
+    """Profile dialog should wrap IP options in a labelled frame."""
+    expected = _expected_label()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets."""
+
+        def __init__(self, *_, **__):
+            pass
+
+        def grid(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            pass
+
+        def rowconfigure(self, *_, **__):
+            pass
+
+        def columnconfigure(self, *_, **__):
+            pass
+
+        def insert(self, *_, **__):
+            pass
+
+        def configure(self, *_, **__):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *_, text="", **__):
+            super().__init__()
+            self._text = text
+
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
+    class DummyEntry(DummyWidget):
+        pass
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *_, textvariable=None, state=None, **__):
+            super().__init__()
+            self._values = []
+
+        def __setitem__(self, key, value):
+            if key == "values":
+                self._values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    dialog = ui.ProfileDialog.__new__(ui.ProfileDialog)
+    dialog.existing_profiles = []
+    dialog.profile = None
+    dialog.logger = logging.getLogger("test")
+
+    master = DummyWidget()
+    dialog.body(master)
+
+    assert isinstance(dialog.ip_frame, DummyLabelFrame)
+    assert dialog.ip_frame.cget("text") == expected
+


### PR DESCRIPTION
## Summary
- group automatic and manual IP controls in an `IP Settings` frame
- cover profile dialog IP frame with unit test

## Testing
- `python -m pytest tests/test_profile_name_labelframe.py tests/test_ip_settings_labelframe.py -q`
- `python -m pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a650780832480270080ef61de09