### PR TITLE
Wrap SSH key selection in labelled frame

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -277,16 +277,20 @@ class ProfileDialog(simpledialog.Dialog):
         self.name_entry.grid(row=0, column=0, sticky="ew")
         self.logger.debug("Profile name field prepared in labelled frame")
 
-        tk.Label(master, text="SSH key:").grid(row=1, column=0, sticky="w")
+        # SSH key selection grouped in a labelled frame
+        self.key_frame = tk.LabelFrame(master, text="SSH key")
+        self.key_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
+        self.key_frame.columnconfigure(0, weight=1)
         # Prepare drop-down of available SSH keys
         self.key_var = tk.StringVar()
         self.key_combo = ttk.Combobox(
-            master, textvariable=self.key_var, state="readonly"
+            self.key_frame, textvariable=self.key_var, state="readonly"
         )
         # Map of key names to file system paths
         self.key_map = self._load_key_map()
         self.key_combo["values"] = list(self.key_map.keys())
-        self.key_combo.grid(row=1, column=1)
+        self.key_combo.grid(row=0, column=0, sticky="ew")
+        self.logger.debug("SSH key selection prepared in labelled frame")
 
         # IP settings grouped for clarity
         self.ip_frame = tk.LabelFrame(master, text="IP Settings")

--- a/tests/ssh_key_label.ini
+++ b/tests/ssh_key_label.ini
@@ -1,0 +1,3 @@
+[label]
+ssh_key=SSH key
+

--- a/tests/test_profile_ssh_key_labelframe.py
+++ b/tests/test_profile_ssh_key_labelframe.py
@@ -1,0 +1,105 @@
+"""Ensure SSH key selection in profile dialog uses a labelled frame."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import logging
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_label() -> str:
+    """Read expected SSH key label from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("ssh_key_label.ini"))
+    return cfg["label"]["ssh_key"]
+
+
+def test_ssh_key_selection_uses_labelframe(monkeypatch) -> None:
+    """Profile dialog should wrap SSH key selection in a labelled frame."""
+    expected = _expected_label()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets."""
+
+        def __init__(self, *_, **__):
+            pass
+
+        def grid(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            pass
+
+        def rowconfigure(self, *_, **__):
+            pass
+
+        def columnconfigure(self, *_, **__):
+            pass
+
+        def insert(self, *_, **__):
+            pass
+
+        def configure(self, *_, **__):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *_, text="", **__):
+            super().__init__()
+            self._text = text
+
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
+    class DummyEntry(DummyWidget):
+        pass
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *_, textvariable=None, state=None, **__):
+            super().__init__()
+            self._values = []
+
+        def __setitem__(self, key, value):
+            if key == "values":
+                self._values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    dialog = ui.ProfileDialog.__new__(ui.ProfileDialog)
+    dialog.existing_profiles = []
+    dialog.profile = None
+    dialog.logger = logging.getLogger("test")
+
+    master = DummyWidget()
+    dialog.body(master)
+
+    assert isinstance(dialog.key_frame, DummyLabelFrame)
+    assert dialog.key_frame.cget("text") == expected
+


### PR DESCRIPTION
## Summary
- group SSH key selection inside a labelled frame in the profile dialog
- test for labelled SSH key frame in profile dialog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71cc3a8188324a6df0e77eac1a3dc