### PR TITLE
Fix profile dialog window resizing

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -229,7 +229,10 @@ def save_pane_layout(coords: List[int], file_path: Union[str, Path] = PANE_LAYOU
 
 
 class ProfileDialog(simpledialog.Dialog):
-    """Dialog window for collecting or editing profile parameters."""
+    """Dialog window for collecting or editing profile parameters.
+
+    The dialog uses a fixed size so users cannot resize the window.
+    """
 
     def __init__(
         self,
@@ -268,6 +271,12 @@ class ProfileDialog(simpledialog.Dialog):
         places the descriptive text in the frame's border with the entry
         widget inside, making the label appear above the input field.
         """
+        # Disallow user resizing to preserve layout integrity
+        if hasattr(self, "resizable") and getattr(self, "tk", None):
+            self.resizable(False, False)
+            self.logger.debug("Profile dialog resize disabled")
+        else:  # pragma: no cover - defensive
+            self.logger.debug("Resize control not supported in this context")
 
         # Profile name container with border and caption above the entry
         self.name_frame = tk.LabelFrame(master, text="Profile name")

--- a/tests/profile_dialog_resizable.ini
+++ b/tests/profile_dialog_resizable.ini
@@ -1,0 +1,3 @@
+[dialog]
+width=false
+height=false

--- a/tests/test_profile_dialog_resizable.py
+++ b/tests/test_profile_dialog_resizable.py
@@ -1,0 +1,113 @@
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _load_cfg():
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_dialog_resizable.ini"))
+    return cfg
+
+
+def test_profile_dialog_not_resizable(monkeypatch):
+    cfg = _load_cfg()
+    expected_width = cfg.getboolean("dialog", "width")
+    expected_height = cfg.getboolean("dialog", "height")
+
+    # Minimal tkinter stubs
+    class DummyEntry:
+        def __init__(self, *a, **k):
+            self.value = ""
+        def grid(self, *a, **k):
+            pass
+        def insert(self, index, value):
+            self.value = value
+        def get(self):
+            return self.value
+        def configure(self, *a, **k):
+            pass
+
+    class DummyLabel:
+        def __init__(self, *a, **k):
+            pass
+        def grid(self, *a, **k):
+            pass
+
+    class DummyLabelFrame(DummyLabel):
+        def __init__(self, *a, text="", **k):
+            super().__init__(*a, **k)
+            self._text = text
+        def columnconfigure(self, *a, **k):
+            pass
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
+    class DummyCombobox:
+        def __init__(self, master=None, textvariable=None, state=""):
+            self.textvariable = textvariable
+            self.values = []
+        def grid(self, *a, **k):
+            pass
+        def __setitem__(self, key, value):
+            if key == "values":
+                self.values = value
+
+    class DummyCheckbutton:
+        def __init__(self, *a, **k):
+            pass
+        def grid(self, *a, **k):
+            pass
+
+    class DummyBooleanVar:
+        def __init__(self, value=False):
+            self._value = value
+        def get(self):
+            return self._value
+        def set(self, val):
+            self._value = val
+
+    class DummyStringVar(DummyBooleanVar):
+        pass
+
+    fake_tk = SimpleNamespace(
+        Label=DummyLabel,
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Checkbutton=DummyCheckbutton,
+        BooleanVar=DummyBooleanVar,
+        StringVar=DummyStringVar,
+        END="end",
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombobox)
+
+    # Import UI module after patching
+    import lighthouse_app.ui as ui
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+
+    # Simplified Dialog base class capturing resizable calls
+    class DummyDialogBase:
+        def __init__(self, parent, title=None):
+            self.resizable_width = None
+            self.resizable_height = None
+            self.tk = True
+            self.body(parent)
+        def resizable(self, width, height):
+            self.resizable_width = width
+            self.resizable_height = height
+        def cancel(self, event=None):
+            pass
+
+    ui.ProfileDialog.__bases__ = (DummyDialogBase,)
+    monkeypatch.setattr(ui.KeyController, "load_keys", lambda self: [])
+
+    dialog = ui.ProfileDialog(None, [])
+
+    assert dialog.resizable_width == expected_width
+    assert dialog.resizable_height == expected_height


### PR DESCRIPTION
## Summary
- prevent manual resizing of the profile creation/edit dialog and log the action
- add regression test ensuring dialog window size is fixed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71e2f62508324b622f17b1151c974