### PR TITLE
feat: add autoconfig section to profile dialog

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -322,6 +322,26 @@ class ProfileDialog(simpledialog.Dialog):
         self.ip_entry.grid(row=1, column=1, sticky="ew")
         self.ip_entry.configure(state="disabled" if auto_default else "normal")
 
+        # Autoconfig settings grouped for clarity
+        self.autoconfig_frame = tk.LabelFrame(master, text="Autoconfig")
+        self.autoconfig_frame.grid(row=3, column=0, columnspan=2, sticky="ew")
+        self.autoconfig_frame.columnconfigure(1, weight=1)
+        self.logger.debug("Autoconfig fields prepared in labelled frame")
+
+        self.autoconfig_var = tk.BooleanVar(value=False)
+        autoconfig_chk = tk.Checkbutton(
+            self.autoconfig_frame,
+            text="Use autoconfig",
+            variable=self.autoconfig_var,
+            command=self._toggle_autoconfig_entry,
+        )
+        autoconfig_chk.grid(row=0, column=0, columnspan=2, sticky="w")
+
+        tk.Label(self.autoconfig_frame, text="URL:").grid(row=1, column=0, sticky="w")
+        self.autoconfig_entry = tk.Entry(self.autoconfig_frame)
+        self.autoconfig_entry.grid(row=1, column=1, sticky="ew")
+        self.autoconfig_entry.configure(state="disabled")
+
         if self.profile is not None:
             self.name_entry.insert(0, self.profile.get("name", ""))
             # Pre-select SSH key based on stored path
@@ -341,6 +361,14 @@ class ProfileDialog(simpledialog.Dialog):
         else:
             self.ip_entry.configure(state="normal")
             self.logger.info("Profile dialog: manual IP selected")
+
+    def _toggle_autoconfig_entry(self) -> None:
+        if self.autoconfig_var.get():
+            self.autoconfig_entry.configure(state="normal")
+            self.logger.info("Profile dialog: autoconfig enabled")
+        else:
+            self.autoconfig_entry.configure(state="disabled")
+            self.logger.info("Profile dialog: autoconfig disabled")
 
     def validate(self) -> bool:  # pragma: no cover - GUI validation
         name = self.name_entry.get().strip()

--- a/tests/autoconfig_label.ini
+++ b/tests/autoconfig_label.ini
@@ -1,0 +1,3 @@
+[label]
+autoconfig=Autoconfig
+

--- a/tests/test_autoconfig_labelframe.py
+++ b/tests/test_autoconfig_labelframe.py
@@ -1,0 +1,113 @@
+"""Ensure autoconfig options in profile dialog are grouped in a labelled frame."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import logging
+
+# Allow importing the application
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_label() -> str:
+    """Read expected autoconfig label from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("autoconfig_label.ini"))
+    return cfg["label"]["autoconfig"]
+
+
+def test_autoconfig_uses_labelframe(monkeypatch) -> None:
+    """Profile dialog should wrap autoconfig options in a labelled frame."""
+    expected = _expected_label()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets."""
+
+        def __init__(self, *_, **__):
+            pass
+
+        def grid(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            pass
+
+        def rowconfigure(self, *_, **__):
+            pass
+
+        def columnconfigure(self, *_, **__):
+            pass
+
+        def insert(self, *_, **__):
+            pass
+
+        def configure(self, *_, **__):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *_, text="", **__):
+            super().__init__()
+            self._text = text
+
+        def cget(self, option):
+            if option == "text":
+                return self._text
+
+    class DummyEntry(DummyWidget):
+        def __init__(self, *_, **__):
+            super().__init__()
+            self.state = ""
+
+        def configure(self, **kwargs):
+            if "state" in kwargs:
+                self.state = kwargs["state"]
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *_, textvariable=None, state=None, **__):
+            super().__init__()
+            self._values = []
+
+        def __setitem__(self, key, value):
+            if key == "values":
+                self._values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    dialog = ui.ProfileDialog.__new__(ui.ProfileDialog)
+    dialog.existing_profiles = []
+    dialog.profile = None
+    dialog.logger = logging.getLogger("test")
+
+    master = DummyWidget()
+    dialog.body(master)
+
+    assert isinstance(dialog.autoconfig_frame, DummyLabelFrame)
+    assert dialog.autoconfig_frame.cget("text") == expected
+    assert dialog.autoconfig_var.get() is False
+    assert dialog.autoconfig_entry.state == "disabled"
+


### PR DESCRIPTION
## Summary
- add Autoconfig section with URL field and checkbox to profile dialog
- log enabling/disabling autoconfig
- cover new UI section with tests

## Testing
- `pip install paramiko sshtunnel -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7205fab888324a9dcf46904e4dce1