### PR TITLE
Ensure dialogs and window resize safely

### DIFF
--- a/tests/dialog_minsize.ini
+++ b/tests/dialog_minsize.ini
@@ -1,0 +1,7 @@
+[profile]
+width = 300
+height = 200
+
+[tunnel]
+width = 360
+height = 240

--- a/tests/profile_master_column.ini
+++ b/tests/profile_master_column.ini
@@ -1,0 +1,2 @@
+[layout]
+weight = 1

--- a/tests/test_dialog_minsize.py
+++ b/tests/test_dialog_minsize.py
@@ -1,0 +1,234 @@
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import logging
+
+# Ensure application importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_sizes():
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("dialog_minsize.ini"))
+    return {
+        "profile": (
+            cfg.getint("profile", "width"),
+            cfg.getint("profile", "height"),
+        ),
+        "tunnel": (
+            cfg.getint("tunnel", "width"),
+            cfg.getint("tunnel", "height"),
+        ),
+    }
+
+
+def test_profile_dialog_sets_minsize(monkeypatch) -> None:
+    sizes = _expected_sizes()
+    expected_w, expected_h = sizes["profile"]
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+        def grid(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+        def columnconfigure(self, *a, **k):
+            pass
+        def rowconfigure(self, *a, **k):
+            pass
+        def insert(self, *a, **k):
+            pass
+        def configure(self, *a, **k):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *a, text="", **k):
+            super().__init__(*a, **k)
+
+    class DummyEntry(DummyWidget):
+        pass
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *a, textvariable=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.values = []
+        def __setitem__(self, key, value):
+            if key == "values":
+                self.values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self.value = value
+        def get(self):
+            return self.value
+        def set(self, v):
+            self.value = v
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    class DummyDialog(ui.ProfileDialog):
+        def __init__(self):
+            self.logger = logging.getLogger("test")
+            self.profile = None
+            self.existing_profiles = []
+            self.minsize_called = None
+            self.tk = True
+
+        def resizable(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def winfo_reqwidth(self):
+            return expected_w
+
+        def winfo_reqheight(self):
+            return expected_h
+
+        def minsize(self, w, h):
+            self.minsize_called = (w, h)
+
+    dialog = DummyDialog()
+    dialog.body(DummyWidget())
+
+    assert dialog.minsize_called == (expected_w, expected_h)
+
+
+def test_tunnel_dialog_sets_minsize(monkeypatch) -> None:
+    sizes = _expected_sizes()
+    expected_w, expected_h = sizes["tunnel"]
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+        def grid(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+        def columnconfigure(self, *a, **k):
+            pass
+        def rowconfigure(self, *a, **k):
+            pass
+        def insert(self, *a, **k):
+            pass
+        def configure(self, *a, **k):
+            pass
+
+    class DummyLabel(DummyWidget):
+        pass
+
+    class DummyEntry(DummyWidget):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.value = ""
+        def get(self):
+            return self.value
+        def insert(self, i, v):
+            self.value = v
+
+    class DummyButton(DummyWidget):
+        pass
+
+    class DummyFrame(DummyWidget):
+        pass
+
+    class DummyLabelFrame(DummyFrame):
+        def __init__(self, *a, text="", **k):
+            super().__init__(*a, **k)
+
+    class DummyListbox(DummyWidget):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.items = []
+        def insert(self, i, v):
+            self.items.append(v)
+        def get(self, a, b):
+            return self.items
+        def delete(self, *a, **k):
+            self.items.clear()
+
+    class DummyCheckbutton(DummyWidget):
+        pass
+
+    class DummyVar:
+        def __init__(self, value=True):
+            self.value = value
+        def get(self):
+            return self.value
+        def set(self, v):
+            self.value = v
+
+    fake_tk = SimpleNamespace(
+        Label=DummyLabel,
+        Entry=DummyEntry,
+        Button=DummyButton,
+        Frame=DummyFrame,
+        LabelFrame=DummyLabelFrame,
+        Listbox=DummyListbox,
+        Checkbutton=DummyCheckbutton,
+        BooleanVar=DummyVar,
+        NORMAL="normal",
+        DISABLED="disabled",
+        END="end",
+    )
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+
+    class DummyDialog(ui.TunnelDialog):
+        def __init__(self):
+            self.existing_tunnels = []
+            self.tunnel = None
+            self.dns_names = []
+            self.logger = logging.getLogger("test")
+            self.minsize_called = None
+            self.tk = True
+
+        def resizable(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def winfo_width(self):
+            return expected_w - 40
+
+        def winfo_height(self):
+            return expected_h - 40
+
+        def winfo_reqwidth(self):
+            return expected_w
+
+        def winfo_reqheight(self):
+            return expected_h
+
+        def geometry(self, *a, **k):
+            pass
+
+        def minsize(self, w, h):
+            self.minsize_called = (w, h)
+
+        def _toggle_dns_widgets(self):
+            pass
+
+    dialog = DummyDialog()
+    dialog.body(object())
+
+    assert dialog.minsize_called == (expected_w, expected_h)
+

--- a/tests/test_main_window_minsize.py
+++ b/tests/test_main_window_minsize.py
@@ -1,0 +1,135 @@
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+# Allow application import
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_size():
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("window_minsize.ini"))
+    return cfg.getint("size", "width"), cfg.getint("size", "height")
+
+
+def test_main_window_minsize(monkeypatch):
+    expected_w, expected_h = _expected_size()
+
+    class DummyRoot:
+        def __init__(self):
+            self.minsize_called = None
+            self.geometry_called = None
+
+        def columnconfigure(self, *a, **k):
+            pass
+
+        def rowconfigure(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def after(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def winfo_reqwidth(self):
+            return expected_w
+
+        def winfo_reqheight(self):
+            return expected_h
+
+        def winfo_width(self):
+            return expected_w - 50
+
+        def winfo_height(self):
+            return expected_h - 50
+
+        def geometry(self, value):
+            self.geometry_called = value
+
+        def minsize(self, w, h):
+            self.minsize_called = (w, h)
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.children = []
+            self.column_weights = {}
+            self.row_weights = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def columnconfigure(self, index, weight=0, **k):
+            self.column_weights[index] = weight
+
+        def rowconfigure(self, index, weight=0, **k):
+            self.row_weights[index] = weight
+
+        def bind(self, *a, **k):
+            pass
+
+        def add(self, child, **k):
+            self.children.append(child)
+
+        def panes(self):
+            return self.children
+
+    class DummyPanedWindow(DummyWidget):
+        pass
+
+    class DummyTreeview(DummyWidget):
+        def heading(self, *a, **k):
+            pass
+
+        def column(self, *a, **k):
+            return 0
+
+        def tag_configure(self, *a, **k):
+            pass
+
+    fake_tk = SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        LabelFrame=DummyWidget,
+        Text=DummyWidget,
+        Button=DummyWidget,
+        BOTH="both",
+        HORIZONTAL="horizontal",
+        GROOVE="groove",
+        END="end",
+    )
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
+
+    class DummyProfileController:
+        def __init__(self, *a, **k):
+            self.active_tunnels = {}
+        def load_profiles(self):
+            return []
+
+    class DummyKeyController:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui, "ProfileController", DummyProfileController)
+    monkeypatch.setattr(ui, "KeyController", DummyKeyController)
+    monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
+    monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)
+
+    cfg = configparser.ConfigParser()
+    cfg["ui"] = {}
+    root = DummyRoot()
+    ui.LighthouseApp(root, cfg)
+
+    assert root.minsize_called == (expected_w, expected_h)
+

--- a/tests/test_profile_master_column.py
+++ b/tests/test_profile_master_column.py
@@ -1,0 +1,98 @@
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import logging
+
+# Allow importing the application package
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _expected_weight() -> int:
+    """Read expected column weight from configuration."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_master_column.ini"))
+    return cfg.getint("layout", "weight")
+
+
+def test_profile_dialog_master_expands(monkeypatch) -> None:
+    expected = _expected_weight()
+
+    class DummyWidget:
+        """Minimal stand-in for Tk widgets."""
+
+        def __init__(self, *args, **kwargs):
+            self.column_weights = {}
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, index, weight=0, **kwargs):
+            self.column_weights[index] = weight
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def insert(self, *args, **kwargs):
+            pass
+
+        def configure(self, *args, **kwargs):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, *args, text="", **kwargs):
+            super().__init__(*args, **kwargs)
+            self._text = text
+
+    class DummyEntry(DummyWidget):
+        pass
+
+    class DummyCombo(DummyWidget):
+        def __init__(self, *_, textvariable=None, state=None, **__):
+            super().__init__()
+            self._values = []
+
+        def __setitem__(self, key, value):
+            if key == "values":
+                self._values = value
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    fake_tk = SimpleNamespace(
+        LabelFrame=DummyLabelFrame,
+        Entry=DummyEntry,
+        Label=DummyWidget,
+        BooleanVar=DummyVar,
+        Checkbutton=DummyWidget,
+        StringVar=DummyVar,
+    )
+    fake_ttk = SimpleNamespace(Combobox=DummyCombo)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui.ProfileDialog, "_load_key_map", staticmethod(lambda: {}))
+
+    dialog = ui.ProfileDialog.__new__(ui.ProfileDialog)
+    dialog.logger = logging.getLogger("test")
+    dialog.profile = None
+    dialog.existing_profiles = []
+
+    master = DummyWidget()
+    dialog.body(master)
+
+    assert master.column_weights.get(0) == expected
+    assert master.column_weights.get(1) == expected
+

--- a/tests/window_minsize.ini
+++ b/tests/window_minsize.ini
@@ -1,0 +1,3 @@
+[size]
+width = 500
+height = 400


### PR DESCRIPTION
## Summary
- Ensure profile dialog root expands horizontally and sets minimum size
- Add minimum-size enforcement for tunnel dialog and main window
- Cover window and dialog sizing with dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5afb3ec8324b8063331357cd269