### PR TITLE
Disable tunnel dialog resizing

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -649,10 +649,16 @@ class TunnelDialog(simpledialog.Dialog):
             self.ssh_port_entry.insert(0, "22")
             self.logger.info("Tunnel dialog: default SSH port 22 inserted")
 
-        # Allow resizing and widen the dialog for comfortable editing
+        # Disable user resizing to maintain a consistent layout
         if hasattr(self, "resizable"):
-            self.resizable(True, True)
-            self.logger.debug("Tunnel dialog made resizable")
+            try:
+                self.resizable(False, False)
+                self.logger.debug("Tunnel dialog resizing disabled")
+            except Exception as exc:  # pragma: no cover - defensive
+                if hasattr(self.logger, "warning"):
+                    self.logger.warning(
+                        "Failed to disable tunnel dialog resizing: %s", exc
+                    )
 
         # Defer geometry enforcement until all widgets, including button box,
         # are created.  ``simpledialog.Dialog`` adds buttons after ``body``

--- a/tests/test_tunnel_dialog_alignment.py
+++ b/tests/test_tunnel_dialog_alignment.py
@@ -17,6 +17,8 @@ def test_tunnel_dialog_alignment(monkeypatch) -> None:
     expected_width = max(len(t) for t in label_texts)
     base_width = cfg.getint("dialog", "base_width")
     extra_width = cfg.getint("dialog", "extra_width")
+    resizable_width = cfg["resizable"].getboolean("width")
+    resizable_height = cfg["resizable"].getboolean("height")
 
     label_widths = []
     entry_stickies = []
@@ -165,4 +167,4 @@ def test_tunnel_dialog_alignment(monkeypatch) -> None:
     assert any((1, 1) in w for w in weights)
 
     assert dialog.geom == f"{base_width + extra_width}x200"
-    assert geometry_called.get("resizable") == (True, True)
+    assert geometry_called.get("resizable") == (resizable_width, resizable_height)

--- a/tests/tunnel_dialog_config.ini
+++ b/tests/tunnel_dialog_config.ini
@@ -10,3 +10,7 @@ dns_name = DNS Name:
 [dialog]
 base_width = 300
 extra_width = 80
+
+[resizable]
+width = false
+height = false


### PR DESCRIPTION
## Summary
- prevent user resizing of the tunnel dialog for stable layout
- adjust tunnel dialog alignment tests to expect non-resizable dialog
- capture resizable expectations from configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e66356888324b49d17fc12534989