### PR TITLE
Исправление Windows-пути для SSH ключей в тестах

### DIFF
--- a/tests/profile_tunnels_test_config.ini
+++ b/tests/profile_tunnels_test_config.ini
@@ -2,7 +2,8 @@
 name = Alice
 ssh_key_filename = id_rsa_alice
 ip = 127.1.1.1
-ssh_dir = /keys
+# Путь к директории с SSH ключами. Используем Windows-путь для тестирования
+ssh_dir = C:\\keys
 
 [tunnel]
 name = web

--- a/tests/test_tunnel_info_display.py
+++ b/tests/test_tunnel_info_display.py
@@ -73,7 +73,8 @@ def test_tunnel_selection_updates_status(monkeypatch) -> None:
         {
             "name": cfg["profile"]["name"],
             "ip": cfg["profile"]["ip"],
-            "ssh_key": f"{cfg['profile']['ssh_dir']}/{cfg['profile']['ssh_key_filename']}",
+            # Формируем путь к ключу через Path, чтобы поддерживать Windows-пути
+            "ssh_key": str(Path(cfg["profile"]["ssh_dir"]) / cfg["profile"]["ssh_key_filename"]),
             "tunnels": [
                 {
                     "name": cfg["tunnel"]["name"],


### PR DESCRIPTION
## Summary
- Указал Windows-путь `C:\\keys` в конфиге `profile_tunnels_test_config.ini`
- Формирую путь к SSH ключу через `Path` в тесте отображения информации о туннелях

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd26aba568832487212cf37b512d94