### PR TITLE
Use home path for default SSH directory in tunnel dialog test

### DIFF
--- a/tests/test_tunnel_dialog_alignment.py
+++ b/tests/test_tunnel_dialog_alignment.py
@@ -106,8 +106,10 @@ def test_tunnel_dialog_alignment(monkeypatch) -> None:
     class DummyForwarder:
         pass
 
+    # Use the user's home directory to emulate the default SSH key location
     fake_sshtunnel = SimpleNamespace(
-        SSHTunnelForwarder=DummyForwarder, DEFAULT_SSH_DIRECTORY="~/.ssh"
+        SSHTunnelForwarder=DummyForwarder,
+        DEFAULT_SSH_DIRECTORY=str(Path.home() / ".ssh"),
     )
     monkeypatch.setitem(sys.modules, "sshtunnel", fake_sshtunnel)
 


### PR DESCRIPTION
## Summary
- use the user's home directory when emulating sshtunnel's default SSH key path in `test_tunnel_dialog_alignment`

## Testing
- `pytest tests/test_tunnel_dialog_alignment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd2b11f40c8324bbb274f3591e70ed