### PR TITLE
Add profile start/stop controls

### DIFF
--- a/lighthouse_app/controllers/profile_controller.py
+++ b/lighthouse_app/controllers/profile_controller.py
@@ -149,3 +149,19 @@ class ProfileController:
 
     def is_tunnel_active(self, profile_name: str, tunnel_name: str) -> bool:
         return self.service.is_tunnel_active(profile_name, tunnel_name)
+
+    def start_profile(
+        self,
+        profile_name: str,
+        file_path: Union[str, Path] = PROFILES_FILE,
+        profiles: Optional[List[Dict[str, str]]] = None,
+        forwarder_cls: type[SSHTunnelForwarder] = SSHTunnelForwarder,
+    ) -> None:
+        """Start all tunnels associated with the given profile."""
+        if profiles is None:
+            profiles = self.load_profiles(file_path)
+        self.service.start_profile(profile_name, file_path, profiles, forwarder_cls)
+
+    def stop_profile(self, profile_name: str) -> None:
+        """Stop all running tunnels for the given profile."""
+        self.service.stop_profile(profile_name)

--- a/tests/test_profile_controller.py
+++ b/tests/test_profile_controller.py
@@ -44,3 +44,25 @@ def test_load_profiles_delegates_to_service(monkeypatch):
     result = controller.load_profiles()
     assert result == expected
     assert called["file_path"] == PROFILES_FILE
+
+
+def test_start_stop_profile_delegates_to_service(monkeypatch):
+    cfg = _load_cfg()
+    controller = ProfileController()
+    name = cfg["profile1"]["name"]
+    called = {}
+
+    def fake_start(profile_name, file_path=PROFILES_FILE, profiles=None, forwarder_cls=None):
+        called["start"] = (profile_name, file_path)
+
+    def fake_stop(profile_name):
+        called["stop"] = profile_name
+
+    monkeypatch.setattr(controller.service, "start_profile", fake_start)
+    monkeypatch.setattr(controller.service, "stop_profile", fake_stop)
+
+    controller.start_profile(name)
+    controller.stop_profile(name)
+
+    assert called["start"] == (name, PROFILES_FILE)
+    assert called["stop"] == name

--- a/tests/test_profile_start_stop.py
+++ b/tests/test_profile_start_stop.py
@@ -1,0 +1,91 @@
+import configparser
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app.controllers.profile_controller import ProfileController
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("profile_tunnels_test_config.ini"))
+    return cfg
+
+
+def test_start_stop_profile(monkeypatch, tmp_path) -> None:
+    cfg = _load_cfg()
+    profile_name = cfg["profile"]["name"]
+    tunnel_cfg = cfg["tunnel"]
+    hosts_file = tmp_path / cfg["hosts"]["file"]
+    hosts_file.write_text("")
+    ssh_key = Path(cfg["profile"]["ssh_dir"]) / cfg["profile"]["ssh_key_filename"]
+    profile_ip = cfg["profile"]["ip"]
+    profiles = [
+        {
+            "name": profile_name,
+            "ssh_key": str(ssh_key),
+            "ip": profile_ip,
+            "tunnels": [
+                {
+                    "name": tunnel_cfg["name"],
+                    "local_port": int(tunnel_cfg["local_port"]),
+                    "remote_host": tunnel_cfg["remote_host"],
+                    "remote_port": int(tunnel_cfg["remote_port"]),
+                    "ssh_host": tunnel_cfg["ssh_host"],
+                    "username": tunnel_cfg["username"],
+                    "ssh_port": int(tunnel_cfg["ssh_port"]),
+                    "dns_names": [
+                        d.strip()
+                        for d in tunnel_cfg["dns_names"].split(",")
+                        if d.strip()
+                    ],
+                    "dns_override": tunnel_cfg.getboolean("dns_override"),
+                }
+            ],
+        }
+    ]
+
+    controller = ProfileController(hosts_file=hosts_file)
+
+    class DummyForwarder:
+        def __init__(self, **kwargs):
+            self.active = False
+
+        def start(self):
+            self.active = True
+
+        def stop(self):
+            self.active = False
+
+        @property
+        def is_active(self):
+            return self.active
+
+    controller.start_profile(
+        profile_name,
+        profiles=profiles,
+        forwarder_cls=DummyForwarder,
+    )
+
+    assert (profile_name, tunnel_cfg["name"]) in controller.active_tunnels
+    dns_line = " ".join(
+        [
+            profile_ip,
+            *[
+                d.strip()
+                for d in tunnel_cfg["dns_names"].split(",")
+                if d.strip()
+            ],
+        ]
+    )
+    expected_block = (
+        f"#### Managed by Lighthouse profile {profile_name} ####\n"
+        f"{dns_line}\n"
+        f"#### End block Lighthouse profile {profile_name} ####\n"
+    )
+    assert hosts_file.read_text() == expected_block
+
+    controller.stop_profile(profile_name)
+    assert controller.active_tunnels == {}
+    assert hosts_file.read_text() == ""

--- a/tests/test_ui_buttons.py
+++ b/tests/test_ui_buttons.py
@@ -106,6 +106,8 @@ def test_buttons_labels(monkeypatch) -> None:
     expected_settings = cfg["buttons"]["settings"]
     expected_manage = cfg["buttons"]["manage_ssh_key"]
     expected_edit = cfg["buttons"]["edit_profile"]
+    expected_start_profile = cfg["buttons"]["start_profile"]
+    expected_stop_profile = cfg["buttons"]["stop_profile"]
     expected_new_tunnel = cfg["buttons"]["new_tunnel"]
     expected_edit_tunnel = cfg["buttons"]["edit_tunnel"]
     expected_delete_tunnel = cfg["buttons"]["delete_tunnel"]
@@ -115,6 +117,8 @@ def test_buttons_labels(monkeypatch) -> None:
     assert expected_settings in labels
     assert expected_manage in labels
     assert expected_edit in labels
+    assert expected_start_profile in labels
+    assert expected_stop_profile in labels
     assert expected_new_tunnel in labels
     assert expected_edit_tunnel in labels
     assert expected_delete_tunnel in labels

--- a/tests/ui_buttons_config.ini
+++ b/tests/ui_buttons_config.ini
@@ -2,6 +2,8 @@
 settings = Settings
 manage_ssh_key = Manage SSH Key
 edit_profile = Edit Profile
+start_profile = Start Profile
+stop_profile = Stop Profile
 new_tunnel = New Tunnel
 edit_tunnel = Edit Tunnel
 delete_tunnel = Delete Tunnel


### PR DESCRIPTION
## Summary
- add Start Profile and Stop Profile buttons to profile panel
- implement controller and service logic to start or stop all tunnels in a profile
- cover profile start/stop operations with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd3e8bde2883249ec658abe5632f58