### PR TITLE
Group profile buttons into management and action sections

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -1135,24 +1135,36 @@ class LighthouseApp:
         self.profile_list.bind("<Double-1>", self._on_profile_double_click)
         # Adjust column widths whenever the widget size changes
         self.profile_list.bind("<Configure>", self._on_profile_list_configure)
+
+        # Group profile controls similarly to tunnel controls to separate
+        # management buttons from action buttons.
+        button_container = tk.Frame(profile_frame)
+        button_container.pack(fill="x")
+
+        manage_frame = tk.LabelFrame(button_container, text="Manage Profiles")
+        manage_frame.pack(side="left", fill="both", expand=True)
+
+        action_frame = tk.LabelFrame(button_container, text="Profile Actions")
+        action_frame.pack(side="left", fill="both", expand=True)
+
         new_profile_btn = tk.Button(
-            profile_frame, text="New Profile", command=self._on_new_profile
+            manage_frame, text="New Profile", command=self._on_new_profile
         )
         new_profile_btn.pack(fill="x")
         edit_btn = tk.Button(
-            profile_frame, text="Edit Profile", command=self._on_edit_profile
+            manage_frame, text="Edit Profile", command=self._on_edit_profile
         )
         edit_btn.pack(fill="x")
         delete_btn = tk.Button(
-            profile_frame, text="Delete Profile", command=self._on_delete_profile
+            manage_frame, text="Delete Profile", command=self._on_delete_profile
         )
         delete_btn.pack(fill="x")
         start_profile_btn = tk.Button(
-            profile_frame, text="Start Profile", command=self._on_start_profile
+            action_frame, text="Start Profile", command=self._on_start_profile
         )
         start_profile_btn.pack(fill="x")
         stop_profile_btn = tk.Button(
-            profile_frame, text="Stop Profile", command=self._on_stop_profile
+            action_frame, text="Stop Profile", command=self._on_stop_profile
         )
         stop_profile_btn.pack(fill="x")
 

--- a/tests/test_profile_button_groups.py
+++ b/tests/test_profile_button_groups.py
@@ -1,0 +1,112 @@
+"""Tests verifying profile buttons are grouped into management and action sections."""
+
+import configparser
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+# Ensure application modules are importable when running tests directly
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lighthouse_app import ui
+
+
+def _load_cfg() -> configparser.ConfigParser:
+    """Load expected group labels from configuration file."""
+    cfg = configparser.ConfigParser()
+    cfg.read(Path(__file__).with_name("ui_buttons_config.ini"))
+    return cfg
+
+
+def test_profile_buttons_grouped(monkeypatch) -> None:
+    """Profile buttons should be separated into management and action groups."""
+
+    cfg = _load_cfg()
+    frame_labels: list[str] = []
+
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def bind(self, *args, **kwargs):
+            pass
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def insert(self, *args, **kwargs):
+            pass
+
+        def after(self, delay, callback, *args):
+            callback(*args)
+
+        def update_idletasks(self):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        def __init__(self, master=None, text="", *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            frame_labels.append(text)
+
+    class DummyButton(DummyWidget):
+        def __init__(self, master=None, text="", command=None):
+            super().__init__()
+
+    class DummyTreeview(DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.columns = {}
+
+        def heading(self, *args, **kwargs):
+            pass
+
+        def column(self, name, width=None, **_):
+            if width is not None:
+                self.columns[name] = width
+            return self.columns.get(name, 0)
+
+        def tag_configure(self, *args, **kwargs):
+            pass
+
+    class DummyPanedWindow(DummyWidget):
+        def add(self, child, **kwargs):
+            pass
+
+    fake_tk = SimpleNamespace(
+        PanedWindow=DummyPanedWindow,
+        Frame=DummyWidget,
+        LabelFrame=DummyLabelFrame,
+        Listbox=DummyWidget,
+        Text=DummyWidget,
+        Button=DummyButton,
+        END="end",
+        HORIZONTAL="horizontal",
+        BOTH="both",
+        GROOVE="groove",
+    )
+    fake_ttk = SimpleNamespace(Treeview=DummyTreeview)
+
+    monkeypatch.setattr(ui, "tk", fake_tk)
+    monkeypatch.setattr(ui, "ttk", fake_ttk)
+    monkeypatch.setattr(ui, "load_pane_layout", lambda file_path=ui.PANE_LAYOUT_FILE: [])
+    monkeypatch.setattr(ui.LighthouseApp, "_setup_logging", lambda self: None)
+    monkeypatch.setattr(ui.LighthouseApp, "_load_profiles_into_list", lambda self: None)
+
+    root = DummyWidget()
+    ui.LighthouseApp(root, cfg)
+
+    expected_manage = cfg["groups"]["manage_profiles"]
+    expected_actions = cfg["groups"]["profile_actions"]
+
+    assert expected_manage in frame_labels
+    assert expected_actions in frame_labels
+

--- a/tests/ui_buttons_config.ini
+++ b/tests/ui_buttons_config.ini
@@ -9,3 +9,9 @@ edit_tunnel = Edit Tunnel
 delete_tunnel = Delete Tunnel
 start_tunnel = Start Tunnel
 stop_tunnel = Stop Tunnel
+
+[groups]
+manage_profiles = Manage Profiles
+profile_actions = Profile Actions
+manage_tunnels = Manage Tunnels
+tunnel_actions = Tunnel Actions


### PR DESCRIPTION
## Summary
- Separate profile management buttons from start/stop actions like tunnel buttons
- Add config values and tests ensuring profile button groups exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd416e0798832491c43dab3cd1d1cd