### PR TITLE
Fix double-click handling for profile and tunnel lists

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -1301,8 +1301,35 @@ class LighthouseApp:
             self._load_tunnels(profile_name)
 
     def _on_profile_double_click(self, event: tk.Event) -> None:  # pragma: no cover - GUI event
-        """Open the profile edit dialog when a profile is double-clicked."""
-        self.logger.info("Profile double-click event")
+        """Open the profile edit dialog when a profile row is double-clicked.
+
+        The handler verifies that the click occurred on a valid row before
+        invoking the edit dialog.  This prevents accidental edits when the user
+        double-clicks an empty area of the profile list.
+        """
+
+        x = getattr(event, "x", None)
+        y = getattr(event, "y", None)
+        btn = getattr(event, "num", None)
+        self.logger.info(
+            "Profile double-click at x=%s y=%s button=%s", x, y, btn
+        )
+
+        try:
+            item_id = event.widget.identify_row(y)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.warning("Failed to identify profile row: %s", exc)
+            return
+
+        if not item_id:
+            self.logger.debug("Double-click ignored: no profile at y=%s", y)
+            return
+
+        try:
+            event.widget.selection_set(item_id)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
         self._on_edit_profile()
 
     def _on_profile_list_configure(self, event: tk.Event) -> None:
@@ -1398,8 +1425,35 @@ class LighthouseApp:
             self.logger.exception("Failed to display tunnel info: %s", exc)
 
     def _on_tunnel_double_click(self, event: tk.Event) -> None:  # pragma: no cover - GUI event
-        """Open the tunnel edit dialog when a tunnel is double-clicked."""
-        self.logger.info("Tunnel double-click event")
+        """Open the tunnel edit dialog when a tunnel row is double-clicked.
+
+        The handler confirms that the user double-clicked an existing tunnel
+        entry.  Double-clicks on empty space are ignored to avoid launching the
+        edit dialog unexpectedly.
+        """
+
+        x = getattr(event, "x", None)
+        y = getattr(event, "y", None)
+        btn = getattr(event, "num", None)
+        self.logger.info(
+            "Tunnel double-click at x=%s y=%s button=%s", x, y, btn
+        )
+
+        try:
+            item_id = event.widget.identify_row(y)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.warning("Failed to identify tunnel row: %s", exc)
+            return
+
+        if not item_id:
+            self.logger.debug("Double-click ignored: no tunnel at y=%s", y)
+            return
+
+        try:
+            event.widget.selection_set(item_id)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
         self._on_edit_tunnel()
 
     def _load_tunnels(self, profile_name: str) -> None:

--- a/tests/test_tunnel_double_click.py
+++ b/tests/test_tunnel_double_click.py
@@ -24,18 +24,32 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
     class DummyTreeview:
         def __init__(self, *_, **__):
             self.bindings = {}
+            self._selected = ()
+
         def pack(self, *_, **__):
             pass
+
         def bind(self, event, callback):
             self.bindings[event] = callback
+
         def heading(self, *_, **__):
             pass
+
         def column(self, *_, **__):
             return 0
+
         def selection(self):
-            return ()
+            return self._selected
+
+        def selection_set(self, item_id):
+            self._selected = (item_id,)
+
+        def identify_row(self, y):
+            return "item0" if y == 1 else ""
+
         def item(self, *_, **__):
             return ()
+
         def tag_configure(self, *args, **kwargs):
             pass
 
@@ -100,5 +114,10 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
 
     event_name = cfg["events"]["double_click"]
     assert event_name in app.tunnel_list.bindings
-    app.tunnel_list.bindings[event_name](None)
+    event = SimpleNamespace(widget=app.tunnel_list, x=0, y=1, num=1)
+    app.tunnel_list.bindings[event_name](event)
     assert calls
+
+    event_blank = SimpleNamespace(widget=app.tunnel_list, x=0, y=99, num=1)
+    app.tunnel_list.bindings[event_name](event_blank)
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- guard profile and tunnel double-click handlers to require clicking on a row
- test that double-clicking empty space does not trigger edit dialogs

## Testing
- `pytest tests/test_profile_double_click.py::test_profile_list_double_click_triggers_edit -q`
- `pytest tests/test_tunnel_double_click.py::test_tunnel_list_double_click_triggers_edit -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd4ff67bc08324ba050573b0cdcbf6