### PR TITLE
Use Treeview focus for double-click edits

### DIFF
--- a/lighthouse_app/ui.py
+++ b/lighthouse_app/ui.py
@@ -1311,25 +1311,27 @@ class LighthouseApp:
         x = getattr(event, "x", None)
         y = getattr(event, "y", None)
         btn = getattr(event, "num", None)
+        tree = event.widget
         self.logger.info(
             "Profile double-click at x=%s y=%s button=%s", x, y, btn
         )
 
         try:
-            item_id = event.widget.identify_row(y)
+            item_id = tree.focus()
         except Exception as exc:  # pragma: no cover - defensive
-            self.logger.warning("Failed to identify profile row: %s", exc)
+            self.logger.warning("Failed to obtain focused profile: %s", exc)
             return
 
         if not item_id:
-            self.logger.debug("Double-click ignored: no profile at y=%s", y)
+            self.logger.debug("Double-click ignored: no profile selected")
             return
 
-        try:
-            event.widget.selection_set(item_id)
+        try:  # Ensure selection reflects focused item for consistency
+            tree.selection_set(item_id)
         except Exception:  # pragma: no cover - defensive
             pass
 
+        self.logger.info("Editing profile id=%s", item_id)
         self._on_edit_profile()
 
     def _on_profile_list_configure(self, event: tk.Event) -> None:
@@ -1435,25 +1437,27 @@ class LighthouseApp:
         x = getattr(event, "x", None)
         y = getattr(event, "y", None)
         btn = getattr(event, "num", None)
+        tree = event.widget
         self.logger.info(
             "Tunnel double-click at x=%s y=%s button=%s", x, y, btn
         )
 
         try:
-            item_id = event.widget.identify_row(y)
+            item_id = tree.focus()
         except Exception as exc:  # pragma: no cover - defensive
-            self.logger.warning("Failed to identify tunnel row: %s", exc)
+            self.logger.warning("Failed to obtain focused tunnel: %s", exc)
             return
 
         if not item_id:
-            self.logger.debug("Double-click ignored: no tunnel at y=%s", y)
+            self.logger.debug("Double-click ignored: no tunnel selected")
             return
 
-        try:
-            event.widget.selection_set(item_id)
+        try:  # Keep selection in sync with focus
+            tree.selection_set(item_id)
         except Exception:  # pragma: no cover - defensive
             pass
 
+        self.logger.info("Editing tunnel id=%s", item_id)
         self._on_edit_tunnel()
 
     def _load_tunnels(self, profile_name: str) -> None:

--- a/tests/test_profile_double_click.py
+++ b/tests/test_profile_double_click.py
@@ -26,6 +26,7 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
             self.bindings = {}
             self.columns = {}
             self._selected = ("item0",)
+            self._focus = "item0"
 
         def pack(self, *_, **__):
             pass
@@ -47,8 +48,8 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
         def selection_set(self, item_id):
             self._selected = (item_id,)
 
-        def identify_row(self, y):
-            return "item0" if y == 1 else ""
+        def focus(self):
+            return self._focus
 
         def item(self, item_id, option=None):
             return ("profile", "127.0.0.1")
@@ -119,9 +120,11 @@ def test_profile_list_double_click_triggers_edit(monkeypatch) -> None:
     event_name = cfg["events"]["double_click"]
     assert event_name in app.profile_list.bindings
     event = SimpleNamespace(widget=app.profile_list, x=0, y=1, num=1)
+    app.profile_list._focus = "item0"
     app.profile_list.bindings[event_name](event)
     assert calls
 
     event_blank = SimpleNamespace(widget=app.profile_list, x=0, y=99, num=1)
+    app.profile_list._focus = ""
     app.profile_list.bindings[event_name](event_blank)
     assert len(calls) == 1

--- a/tests/test_tunnel_double_click.py
+++ b/tests/test_tunnel_double_click.py
@@ -25,6 +25,7 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
         def __init__(self, *_, **__):
             self.bindings = {}
             self._selected = ()
+            self._focus = ""
 
         def pack(self, *_, **__):
             pass
@@ -44,8 +45,8 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
         def selection_set(self, item_id):
             self._selected = (item_id,)
 
-        def identify_row(self, y):
-            return "item0" if y == 1 else ""
+        def focus(self):
+            return self._focus
 
         def item(self, *_, **__):
             return ()
@@ -115,9 +116,11 @@ def test_tunnel_list_double_click_triggers_edit(monkeypatch) -> None:
     event_name = cfg["events"]["double_click"]
     assert event_name in app.tunnel_list.bindings
     event = SimpleNamespace(widget=app.tunnel_list, x=0, y=1, num=1)
+    app.tunnel_list._focus = "item0"
     app.tunnel_list.bindings[event_name](event)
     assert calls
 
     event_blank = SimpleNamespace(widget=app.tunnel_list, x=0, y=99, num=1)
+    app.tunnel_list._focus = ""
     app.tunnel_list.bindings[event_name](event_blank)
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- Simplify profile and tunnel double-click handlers to use Treeview focus
- Ignore empty-area double-clicks and log selected IDs
- Update unit tests for new focus-based behaviour

## Testing
- `pytest tests/test_profile_double_click.py tests/test_tunnel_double_click.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d38e8c08324b4792ac867661cda